### PR TITLE
Add unused import check

### DIFF
--- a/qc_otx/checks/core_checker/__init__.py
+++ b/qc_otx/checks/core_checker/__init__.py
@@ -2,3 +2,4 @@ from . import core_constants as core_constants
 from . import core_checker as core_checker
 from . import document_name_matches_filename as document_name_matches_filename
 from . import document_name_package_uniqueness as document_name_package_uniqueness
+from . import no_unused_imports as no_unused_imports

--- a/qc_otx/checks/core_checker/core_checker.py
+++ b/qc_otx/checks/core_checker/core_checker.py
@@ -11,6 +11,7 @@ from qc_otx.checks.core_checker import (
     core_constants,
     document_name_matches_filename,
     document_name_package_uniqueness,
+    no_unused_imports,
 )
 
 
@@ -25,8 +26,9 @@ def run_checks(checker_data: models.CheckerData) -> None:
     )
 
     rule_list = [
-        document_name_matches_filename.check_rule,
-        document_name_package_uniqueness.check_rule,
+        document_name_matches_filename.check_rule,  # Chk001
+        document_name_package_uniqueness.check_rule,  # Chk002
+        no_unused_imports.check_rule,  # Chk004
     ]
 
     for rule in rule_list:

--- a/qc_otx/checks/core_checker/no_unused_imports.py
+++ b/qc_otx/checks/core_checker/no_unused_imports.py
@@ -50,12 +50,21 @@ def check_rule(checker_data: models.CheckerData) -> None:
         import_prefix = import_node.get("prefix")
         import_package = import_node.get("package")
         import_document = import_node.get("document")
+        import_path = root.getpath(import_node)
         used_prefix_str = import_prefix + ":"
         if is_prefix_never_used_in_attributes(otx_document_attributes, used_prefix_str):
-            checker_data.result.register_issue(
+            issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
                 checker_id=core_constants.CHECKER_ID,
-                description=f"Imported otx document [package: {import_package}, document:{import_document}, prefix:{import_prefix}] is never used in current document",
+                description="Issue flagging when an imported otx document is never used in the current otx",
                 level=IssueSeverity.WARNING,
                 rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=core_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=import_path,
+                description=f"Imported otx document [package: {import_package}, document:{import_document}, prefix:{import_prefix}] is never used in current document",
             )

--- a/qc_otx/checks/core_checker/no_unused_imports.py
+++ b/qc_otx/checks/core_checker/no_unused_imports.py
@@ -42,7 +42,6 @@ def check_rule(checker_data: models.CheckerData) -> None:
     root = tree.getroot()
 
     import_nodes = root.findall(".//import", namespaces=root.nsmap)
-    print(import_nodes)
     xpath_query = "//@*"
     otx_document_attributes = root.xpath(xpath_query)
 

--- a/qc_otx/checks/core_checker/no_unused_imports.py
+++ b/qc_otx/checks/core_checker/no_unused_imports.py
@@ -1,14 +1,13 @@
 import logging, os
 
-from dataclasses import dataclass
 from typing import List
 
 from lxml import etree
 
-from qc_baselib import Configuration, Result, IssueSeverity
+from qc_baselib import Result, IssueSeverity
 
 from qc_otx import constants
-from qc_otx.checks import utils, models
+from qc_otx.checks import models
 
 from qc_otx.checks.core_checker import core_constants
 

--- a/qc_otx/checks/core_checker/no_unused_imports.py
+++ b/qc_otx/checks/core_checker/no_unused_imports.py
@@ -1,0 +1,62 @@
+import logging, os
+
+from dataclasses import dataclass
+from typing import List
+
+from lxml import etree
+
+from qc_baselib import Configuration, Result, IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import utils, models
+
+from qc_otx.checks.core_checker import core_constants
+
+
+def is_prefix_never_used_in_attributes(attributes: List, prefix: str) -> bool:
+    # Check if the prefix is never used in any attribute value
+    for attr in attributes:
+        if prefix in attr:
+            return False  # Found the prefix in an attribute value
+    return True  # Prefix is never used in any attribute value
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements core checker rule Core_Chk004
+    Criterion: An imported OTX document should be used at least once in the importing document.
+    Severity: Warning
+
+    """
+    logging.info("Executing no_unused_imports check")
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=core_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="core.chk_004.no_unused_imports",
+    )
+
+    root = checker_data.input_file_xml_root
+
+    namespaces = {"ns": "http://iso.org/OTX/1.0.0"}
+    import_nodes = root.findall(".//ns:import", namespaces)
+
+    xpath_query = "//@*"
+    otx_document_attributes = root.xpath(xpath_query)
+
+    for import_node in import_nodes:
+        import_prefix = import_node.get("prefix")
+        import_package = import_node.get("package")
+        import_document = import_node.get("document")
+        used_prefix_str = import_prefix + ":"
+        if is_prefix_never_used_in_attributes(otx_document_attributes, used_prefix_str):
+            checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=core_constants.CHECKER_ID,
+                description=f"Imported otx document [package: {import_package}, document:{import_document}, prefix:{import_prefix}] is never used in current document",
+                level=IssueSeverity.WARNING,
+                rule_uid=rule_uid,
+            )

--- a/tests/data/Core_Chk004/Core_Chk004_negative.otx
+++ b/tests/data/Core_Chk004/Core_Chk004_negative.otx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+    name="Core_Chk004_negative"
+    package="Core_Chk004"
+    version="1.0"
+    timestamp="2010-11-11T14:40:10">
+
+    <imports>
+        <import package="org.iso.otx.examples" document="Signatures" prefix="sig" />
+        <import package="org.iso.otx.examples" document="Validities" prefix="val" />
+    </imports>
+
+    <procedures>
+        <procedure name="test" implements="sig:mySignature" id="2-1">
+            <specification> A test procedure </specification>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/Core_Chk004/Core_Chk004_positive.otx
+++ b/tests/data/Core_Chk004/Core_Chk004_positive.otx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+  name="Core_Chk004_positive"
+  package="Core_Chk004"
+  version="1.0"
+  timestamp="2010-11-11T14:40:10">
+
+  <imports>
+    <import package="org.iso.otx.examples" document="Signatures" prefix="sig" />
+  </imports>
+
+  <procedures>
+    <procedure name="test" implements="sig:mySignature" id="2-1">
+      <specification> A test procedure </specification>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -97,3 +97,47 @@ def test_chk002_negative(
     assert core_issues[0].level == IssueSeverity.ERROR
 
     test_utils.cleanup_files()
+
+
+def test_chk004_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk004"
+    target_file_name = f"Core_Chk004_positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_004.no_unused_imports"
+    )
+    assert len(core_issues) == 0
+    test_utils.cleanup_files()
+
+
+def test_chk004_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk004"
+    target_file_name = f"Core_Chk004_negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_004.no_unused_imports"
+    )
+    assert len(core_issues) == 1
+    assert core_issues[0].level == IssueSeverity.WARNING
+
+    test_utils.cleanup_files()


### PR DESCRIPTION
**Description**

Add unused import check - Core_Chk004
Criterion: An imported OTX document should be used at least once in the importing document.
Severity: Warning


**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.

**Notes**
