### PR TITLE
Add no dead import check

### DIFF
--- a/qc_otx/checks/core_checker/__init__.py
+++ b/qc_otx/checks/core_checker/__init__.py
@@ -3,3 +3,4 @@ from . import core_checker as core_checker
 from . import document_name_matches_filename as document_name_matches_filename
 from . import document_name_package_uniqueness as document_name_package_uniqueness
 from . import no_unused_imports as no_unused_imports
+from . import no_dead_import_links as no_dead_import_links

--- a/qc_otx/checks/core_checker/core_checker.py
+++ b/qc_otx/checks/core_checker/core_checker.py
@@ -11,6 +11,7 @@ from qc_otx.checks.core_checker import (
     core_constants,
     document_name_matches_filename,
     document_name_package_uniqueness,
+    no_dead_import_links,
     no_unused_imports,
 )
 
@@ -28,6 +29,7 @@ def run_checks(checker_data: models.CheckerData) -> None:
     rule_list = [
         document_name_matches_filename.check_rule,  # Chk001
         document_name_package_uniqueness.check_rule,  # Chk002
+        no_dead_import_links.check_rule,  # Chk003
         no_unused_imports.check_rule,  # Chk004
     ]
 

--- a/tests/data/Core_Chk003/Core_Chk003_negative.otx
+++ b/tests/data/Core_Chk003/Core_Chk003_negative.otx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+    name="Core_Chk003_negative"
+    package="Core_Chk003"
+    version="1.0"
+    timestamp="2010-11-11T14:40:10">
+
+    <imports>
+        <import package="org.iso.otx.examples" document="foo" prefix="foo" />
+    </imports>
+    <procedures>
+        <procedure name="test" implements="foo:myImport" id="2-1">
+            <specification> A test procedure </specification>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/Core_Chk003/Core_Chk003_positive.otx
+++ b/tests/data/Core_Chk003/Core_Chk003_positive.otx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+    name="Core_Chk003_positive"
+    package="Core_Chk003"
+    version="1.0"
+    timestamp="2010-11-11T14:40:10">
+
+    <imports>
+        <import package="org.iso.otx.examples" document="ImportExample" prefix="imp" />
+    </imports>
+    <procedures>
+        <procedure name="test" implements="imp:myImport" id="2-1">
+            <specification> A test procedure </specification>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/Core_Chk003/org/iso/otx/examples/ImportExample.otx
+++ b/tests/data/Core_Chk003/org/iso/otx/examples/ImportExample.otx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="1"
+    name="ImportExample"
+    package="org.iso.otx.examples"
+    version="1.0"
+    timestamp="2010-03-18T14:40:10">
+
+    <specification> Example for showing the OTX document root structure </specification>
+</otx>

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -99,6 +99,50 @@ def test_chk002_negative(
     test_utils.cleanup_files()
 
 
+def test_chk003_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk003"
+    target_file_name = f"Core_Chk003_positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_003.no_dead_import_links"
+    )
+    assert len(core_issues) == 0
+    test_utils.cleanup_files()
+
+
+def test_chk003_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk003"
+    target_file_name = f"Core_Chk003_negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_003.no_dead_import_links"
+    )
+    assert len(core_issues) == 1
+    assert core_issues[0].level == IssueSeverity.ERROR
+
+    test_utils.cleanup_files()
+
+
 def test_chk004_positive(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
**Description**

Implements core checker rule Core_Chk003
Criterion: Imported OTX documents (referenced by package name and document name via <import> elements)
should exist and should be accessible.
Severity: Critical

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.
**Notes**
