### PR TITLE
Add specification realisation check

### DIFF
--- a/qc_otx/checks/core_checker/__init__.py
+++ b/qc_otx/checks/core_checker/__init__.py
@@ -4,3 +4,6 @@ from . import document_name_matches_filename as document_name_matches_filename
 from . import document_name_package_uniqueness as document_name_package_uniqueness
 from . import no_unused_imports as no_unused_imports
 from . import no_dead_import_links as no_dead_import_links
+from . import (
+    have_specification_if_no_realisation_exists as have_specification_if_no_realisation_exists,
+)

--- a/qc_otx/checks/core_checker/core_checker.py
+++ b/qc_otx/checks/core_checker/core_checker.py
@@ -13,6 +13,7 @@ from qc_otx.checks.core_checker import (
     document_name_package_uniqueness,
     no_dead_import_links,
     no_unused_imports,
+    have_specification_if_no_realisation_exists,
 )
 
 
@@ -31,6 +32,7 @@ def run_checks(checker_data: models.CheckerData) -> None:
         document_name_package_uniqueness.check_rule,  # Chk002
         no_dead_import_links.check_rule,  # Chk003
         no_unused_imports.check_rule,  # Chk004
+        have_specification_if_no_realisation_exists.check_rule,  # Chk007
     ]
 
     for rule in rule_list:

--- a/qc_otx/checks/core_checker/have_specification_if_no_realisation_exists.py
+++ b/qc_otx/checks/core_checker/have_specification_if_no_realisation_exists.py
@@ -1,0 +1,83 @@
+import logging, os
+
+from typing import List
+
+from lxml import etree
+
+from qc_baselib import Result, IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models
+
+from qc_otx.checks.core_checker import core_constants
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements core checker rule Core_Chk007
+    Criterion: For all elements with specification and realisation parts in an OTX document:
+    if there is no <realisation> given, the according <specification> element should exist
+    and have content (no empty string).
+    Severity: Warning
+    """
+    logging.info("Executing have_specification_if_no_realisation_exists check")
+
+    issue_severity = IssueSeverity.WARNING
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=core_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="core.chk_007.have_specification_if_no_realisation_exists",
+    )
+
+    tree = checker_data.input_file_xml_root
+    root = tree.getroot()
+
+    # Define the type you are looking for
+    desired_type = "specification"
+    desired_sibling_name = "realisation"
+
+    # Use XPath to find all nodes of the specified type
+    specification_nodes = tree.xpath(f"//*[local-name() = '{desired_type}']")
+
+    # Check siblings for each specification node
+    for spec_node in specification_nodes:
+
+        current_has_content = spec_node.text is not None
+
+        current_siblings = []
+        parent = spec_node.getparent()
+        if parent is not None:
+            siblings = parent.getchildren()
+            for sibling in siblings:
+                if sibling != spec_node and sibling.tag.endswith(desired_sibling_name):
+                    current_siblings.append(sibling)
+
+        has_issue = len(current_siblings) == 0 and not current_has_content
+
+        current_xpath = tree.getpath(spec_node)
+        print("node.text ", spec_node.text)
+        print("current_xpath ", current_xpath)
+        print("current_has_content ", current_has_content)
+        if has_issue:
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=core_constants.CHECKER_ID,
+                description="Issue flagging when specification node with no realisation has empty content",
+                level=issue_severity,
+                rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=core_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=current_xpath,
+                description=f"Specification node {current_xpath} has no realisation and empty string as content",
+            )
+
+        # print("Found a sibling with the name 'realisation':")
+        # print(etree.tostring(sibling, pretty_print=True).decode("utf-8"))

--- a/qc_otx/checks/core_checker/have_specification_if_no_realisation_exists.py
+++ b/qc_otx/checks/core_checker/have_specification_if_no_realisation_exists.py
@@ -36,11 +36,11 @@ def check_rule(checker_data: models.CheckerData) -> None:
     tree = checker_data.input_file_xml_root
     root = tree.getroot()
 
-    # Define the type you are looking for
+    # Define the node names involved in the check
     desired_type = "specification"
     desired_sibling_name = "realisation"
 
-    # Use XPath to find all nodes of the specified type
+    # Use XPath to find all nodes of the "specification" type
     specification_nodes = tree.xpath(f"//*[local-name() = '{desired_type}']")
 
     # Check siblings for each specification node
@@ -59,9 +59,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
         has_issue = len(current_siblings) == 0 and not current_has_content
 
         current_xpath = tree.getpath(spec_node)
-        print("node.text ", spec_node.text)
-        print("current_xpath ", current_xpath)
-        print("current_has_content ", current_has_content)
+
         if has_issue:
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
@@ -78,6 +76,3 @@ def check_rule(checker_data: models.CheckerData) -> None:
                 xpath=current_xpath,
                 description=f"Specification node {current_xpath} has no realisation and empty string as content",
             )
-
-        # print("Found a sibling with the name 'realisation':")
-        # print(etree.tostring(sibling, pretty_print=True).decode("utf-8"))

--- a/qc_otx/checks/core_checker/have_specification_if_no_realisation_exists.py
+++ b/qc_otx/checks/core_checker/have_specification_if_no_realisation_exists.py
@@ -55,7 +55,9 @@ def check_rule(checker_data: models.CheckerData) -> None:
         has_realisation = node.find("realisation") is not None
         has_specification = node.find("specification") is not None
         specification_has_content = (
-            has_specification and node.find("specification").text is not None
+            has_specification
+            and node.find("specification").text is not None
+            and node.find("specification").text != '""'
         )
 
         is_valid = True

--- a/tests/data/Core_Chk007/Core_Chk007_negative.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_negative.otx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+  name="Core_Chk007_negative"
+  package="Core_Chk007"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <validities>
+    <validity name="Assembly" id="4-v2">
+      <specification>Valid if executed at an assembly line</specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="AssemblyLine" />
+      </realisation>
+    </validity>
+    <validity name="Workshop" id="4-v1">
+      <specification></specification>
+    </validity>
+  </validities>
+
+</otx>

--- a/tests/data/Core_Chk007/Core_Chk007_negative_empty_string.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_negative_empty_string.otx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx id="2"
+  name="Core_Chk007_negative"
+  package="Core_Chk007"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <validities>
+    <validity name="Assembly" id="4-v2">
+      <specification>Valid if executed at an assembly line</specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="AssemblyLine" />
+      </realisation>
+    </validity>
+    <!-- Workshop validity has no realisation and a specification with empty string -->
+    <validity name="Workshop" id="4-v1">
+      <specification>""</specification>
+    </validity>
+  </validities>
+
+</otx>

--- a/tests/data/Core_Chk007/Core_Chk007_negative_no_specification.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_negative_no_specification.otx
@@ -15,9 +15,8 @@
         <term xsi:type="StringLiteral" value="AssemblyLine" />
       </realisation>
     </validity>
-    <!-- Workshop validity has no realisation and an empty specification -->
-    <validity name="Workshop" id="4-v1">
-      <specification></specification>
+    <!-- Workshop validity has no realisation and no realisation -->
+    <validity name="Workshop" id=" 4-v1">
     </validity>
   </validities>
 

--- a/tests/data/Core_Chk007/Core_Chk007_positive.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_positive.otx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+  name="Core_Chk007_positive"
+  package="Core_Chk007"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <validities>
+    <validity name="Workshop" id="4-v1">
+      <specification>Valid if executed in a workshop environment</specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="DealershopWorkshop" />
+      </realisation>
+    </validity>
+    <validity name="Assembly" id="4-v2">
+      <specification>Valid if executed at an assembly line</specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="AssemblyLine" />
+      </realisation>
+    </validity>
+  </validities>
+
+</otx>

--- a/tests/data/Core_Chk007/Core_Chk007_positive.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_positive.otx
@@ -1,25 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+<otx id="2"
   name="Core_Chk007_positive"
   package="Core_Chk007"
   version="1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
   timestamp="2010-11-11T14:40:10">
 
   <validities>
-    <validity name="Workshop" id="4-v1">
+    <validity name="Workshop" id=" 4-v1">
       <specification>Valid if executed in a workshop environment</specification>
-      <realisation xsi:type="IsEqual">
-        <term xsi:type="StringValue" valueOf="context:LOCATION" />
-        <term xsi:type="StringLiteral" value="DealershopWorkshop" />
+      <realisation xsi:type=" IsEqual">
+        <term xsi:type=" StringValue" valueOf=" context:LOCATION" />
+        <term xsi:type=" StringLiteral" value=" DealershopWorkshop" />
       </realisation>
     </validity>
-    <validity name="Assembly" id="4-v2">
+    <validity name=" Assembly" id=" 4-v2">
       <specification>Valid if executed at an assembly line</specification>
-      <realisation xsi:type="IsEqual">
-        <term xsi:type="StringValue" valueOf="context:LOCATION" />
-        <term xsi:type="StringLiteral" value="AssemblyLine" />
+      <realisation xsi:type=" IsEqual">
+        <term xsi:type=" StringValue" valueOf=" context:LOCATION" />
+        <term xsi:type=" StringLiteral" value=" AssemblyLine" />
       </realisation>
     </validity>
   </validities>

--- a/tests/data/Core_Chk007/Core_Chk007_positive_no_realisation.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_positive_no_realisation.otx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+  name="Core_Chk007_positive_no_realisation"
+  package="Core_Chk007"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <validities>
+    <validity name="Workshop" id="4-v1">
+      <specification>Valid if executed in a workshop environment</specification>
+    </validity>
+    <validity name="Assembly" id="4-v2">
+      <specification>Valid if executed at an assembly line</specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="AssemblyLine" />
+      </realisation>
+    </validity>
+  </validities>
+
+</otx>

--- a/tests/data/Core_Chk007/Core_Chk007_positive_no_specification.otx
+++ b/tests/data/Core_Chk007/Core_Chk007_positive_no_specification.otx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0" id="2"
+  name="Core_Chk007_positive_no_specification"
+  package="Core_Chk007"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <validities>
+    <validity name="Workshop" id="4-v1">
+      <specification></specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="DealershopWorkshop" />
+      </realisation>
+    </validity>
+    <validity name="Assembly" id="4-v2">
+      <specification>Valid if executed at an assembly line</specification>
+      <realisation xsi:type="IsEqual">
+        <term xsi:type="StringValue" valueOf="context:LOCATION" />
+        <term xsi:type="StringLiteral" value="AssemblyLine" />
+      </realisation>
+    </validity>
+  </validities>
+
+</otx>

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -294,3 +294,26 @@ def test_chk007_negative_no_specification(
     assert core_issues[0].level == IssueSeverity.WARNING
 
     test_utils.cleanup_files()
+
+
+def test_chk007_negative_empty_string(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk007"
+    target_file_name = f"Core_Chk007_negative_empty_string.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists"
+    )
+    assert len(core_issues) == 1
+    assert core_issues[0].level == IssueSeverity.WARNING
+
+    test_utils.cleanup_files()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -185,3 +185,89 @@ def test_chk004_negative(
     assert core_issues[0].level == IssueSeverity.WARNING
 
     test_utils.cleanup_files()
+
+
+def test_chk007_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk007"
+    target_file_name = f"Core_Chk007_positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists"
+    )
+    assert len(core_issues) == 0
+    test_utils.cleanup_files()
+
+
+def test_chk007_positive_no_specification(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk007"
+    target_file_name = f"Core_Chk007_positive_no_specification.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists"
+    )
+    assert len(core_issues) == 0
+    test_utils.cleanup_files()
+
+
+def test_chk007_positive_no_realisation(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk007"
+    target_file_name = f"Core_Chk007_positive_no_realisation.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists"
+    )
+    assert len(core_issues) == 0
+    test_utils.cleanup_files()
+
+
+def test_chk007_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk007"
+    target_file_name = f"Core_Chk007_negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists"
+    )
+    assert len(core_issues) == 1
+    assert core_issues[0].level == IssueSeverity.WARNING
+
+    test_utils.cleanup_files()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -271,3 +271,26 @@ def test_chk007_negative(
     assert core_issues[0].level == IssueSeverity.WARNING
 
     test_utils.cleanup_files()
+
+
+def test_chk007_negative_no_specification(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk007"
+    target_file_name = f"Core_Chk007_negative_no_specification.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists"
+    )
+    assert len(core_issues) == 1
+    assert core_issues[0].level == IssueSeverity.WARNING
+
+    test_utils.cleanup_files()


### PR DESCRIPTION
**Description**

Add Core_Check_007 – have specification if no realisation exists
Severity: Warning
Criterion: For all elements with specification and realisation parts in an OTX document: if there is no <realisation> given, the according <specification> element should exist and have content (no empty string).

Add tests data and implement tests

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.

**Notes**
