### PR TITLE
Add unique name in procedure check

### DIFF
--- a/qc_otx/checks/core_checker/__init__.py
+++ b/qc_otx/checks/core_checker/__init__.py
@@ -9,3 +9,4 @@ from . import (
 )
 from . import public_main_procedure as public_main_procedure
 from . import mandatory_constant_initialization as mandatory_constant_initialization
+from . import unique_node_names as unique_node_names

--- a/qc_otx/checks/core_checker/core_checker.py
+++ b/qc_otx/checks/core_checker/core_checker.py
@@ -16,6 +16,7 @@ from qc_otx.checks.core_checker import (
     have_specification_if_no_realisation_exists,
     public_main_procedure,
     mandatory_constant_initialization,
+    unique_node_names,
 )
 
 
@@ -37,6 +38,7 @@ def run_checks(checker_data: models.CheckerData) -> None:
         have_specification_if_no_realisation_exists.check_rule,  # Chk007
         public_main_procedure.check_rule,  # Chk008
         mandatory_constant_initialization.check_rule,  # Chk009
+        unique_node_names.check_rule,  # Chk010
     ]
 
     for rule in rule_list:

--- a/qc_otx/checks/core_checker/unique_node_names.py
+++ b/qc_otx/checks/core_checker/unique_node_names.py
@@ -1,0 +1,87 @@
+import logging, os
+
+from typing import List
+
+from lxml import etree
+
+from qc_baselib import Result, IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models
+
+from qc_otx.checks.core_checker import core_constants
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Implements core checker rule Core_Chk010
+    Criterion: The value of a nodes name attribute should be unique among all nodes in a procedure.
+    Severity: Warning
+    """
+    logging.info("Executing unique_node_names check")
+
+    issue_severity = IssueSeverity.WARNING
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=core_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="core.chk_010.unique_node_names",
+    )
+
+    tree = checker_data.input_file_xml_root
+    root = tree.getroot()
+    # Use XPath to find all nodes procedure
+    procedure_nodes = tree.xpath("//procedure")
+
+    for procedure_node in procedure_nodes:
+        procedure_name = procedure_node.get("name")
+
+        # Define the XPath expression to find all elements with a "name" attribute
+        xpath_expr = ".//*[@name]"
+
+        # Use XPath to find all matching elements from the given procedure node
+        result = procedure_node.xpath(xpath_expr)
+
+        # Dictionary to store the found names and their corresponding XPath expressions
+        name_to_xpath = {}
+        duplicates = {}
+
+        # Build the XPaths for elements and check for duplicates
+        for elem in result:
+            name = elem.get("name")
+            xpath = tree.getpath(elem)
+
+            if name in name_to_xpath:
+                if name not in duplicates:
+                    duplicates[name] = [name_to_xpath[name]]
+                duplicates[name].append(xpath)
+            else:
+                name_to_xpath[name] = xpath
+
+        for name, xpaths in duplicates.items():
+            if len(xpaths) == 0:
+                continue
+
+            error_string = f"Duplicated name {name}"
+            for xpath in xpaths:
+                error_string += f" defined at {xpath}"
+
+            current_xpath = xpaths[0]
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=core_constants.CHECKER_ID,
+                description="Issue flagging when nodes with same attribute name are found in a procedure",
+                level=issue_severity,
+                rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=core_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=current_xpath,
+                description=f"Procedure {procedure_name} at {current_xpath} contains duplicated name. {error_string}",
+            )

--- a/qc_otx/checks/core_checker/unique_node_names.py
+++ b/qc_otx/checks/core_checker/unique_node_names.py
@@ -56,23 +56,22 @@ def check_rule(checker_data: models.CheckerData) -> None:
         result = procedure_node.xpath(xpath_expr)
 
         # Dictionary to store the found names and their corresponding XPath expressions
-        name_to_xpath = {}
-        duplicates = {}
+        name_map = dict()
 
         # Build the XPaths for elements and check for duplicates
         for elem in result:
             name = elem.get("name")
+            if name is None:
+                continue
             xpath = tree.getpath(elem)
 
-            if name in name_to_xpath:
-                if name not in duplicates:
-                    duplicates[name] = [name_to_xpath[name]]
-                duplicates[name].append(xpath)
-            else:
-                name_to_xpath[name] = xpath
+            if name not in name_map:
+                name_map[name] = []
 
-        for name, xpaths in duplicates.items():
-            if len(xpaths) == 0:
+            name_map[name].append(xpath)
+
+        for name, xpaths in name_map.items():
+            if len(xpaths) <= 1:
                 continue
 
             error_string = f"Duplicated name {name}"

--- a/qc_otx/checks/core_checker/unique_node_names.py
+++ b/qc_otx/checks/core_checker/unique_node_names.py
@@ -14,9 +14,19 @@ from qc_otx.checks.core_checker import core_constants
 
 def check_rule(checker_data: models.CheckerData) -> None:
     """
-    Implements core checker rule Core_Chk010
-    Criterion: The value of a nodes name attribute should be unique among all nodes in a procedure.
-    Severity: Warning
+    Rule ID: asam.net:otx:1.0.0:core.chk_010.unique_node_names
+
+    Description: The value of a nodes name attribute should be unique among all nodes in a procedure.
+
+    Severity: WARNING
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    More info at
+        -
     """
     logging.info("Executing unique_node_names check")
 

--- a/tests/data/Core_Chk010/Core_Chk010_negative.otx
+++ b/tests/data/Core_Chk010/Core_Chk010_negative.otx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx id="2"
+  name="Core_Chk010_negative"
+  package="Core_Chk010"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <imports>
+    <import package="org.iso.otx.examples" document="Signatures" prefix="sig" />
+  </imports>
+
+
+  <procedures>
+    <procedure name="main" visibility="PUBLIC" id="20-p1">
+      <specification>Demonstration of variable, constant and parameter declarations</specification>
+      <realisation>
+        <declarations>
+          <variable name="x" id="20-d1" />
+        </declarations>
+        <flow>
+          <action id="call1">
+            <specification>Calls procedure located in same document</specification>
+            <realisation xsi:type="ProcedureCall" procedure="ComputeDelta">
+              <arguments>
+                <inArg param="a" name="a">
+                  <term xsi:type="IntegralLiteral" value="5" />
+                </inArg>
+                <inArg param="b">
+                  <term xsi:type="IntegralValue" valueOf="x" />
+                </inArg>
+                <outArg param="delta">
+                  <variable xsi:type="IntegerVariable" name="a" />
+                </outArg>
+              </arguments>
+            </realisation>
+          </action>
+          <action id="call2">
+            <specification>Calls procedure by an external signature</specification>
+            <realisation xsi:type="ProcedureCall" procedure="sig:modifyValue">
+              <arguments>
+                <inoutArg param="value">
+                  <variable xsi:type="IntegerVariable" name="x" />
+                </inoutArg>
+              </arguments>
+            </realisation>
+          </action>
+        </flow>
+      </realisation>
+    </procedure>
+    <procedure name="computeDelta" id="20-p2">
+      <specification>Computes the difference between two values</specification>
+      <realisation>
+        <parameters>
+          <inParam name="b" id="20-d2" />
+          <inParam name="b" id="20-d3" />
+          <outParam name="delta" id="20-d4" />
+        </parameters>
+        <flow />
+      </realisation>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/data/Core_Chk010/Core_Chk010_positive.otx
+++ b/tests/data/Core_Chk010/Core_Chk010_positive.otx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otx id="2"
+  name="Core_Chk010_positive"
+  package="Core_Chk010"
+  version="1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 Core/otx.xsd"
+  timestamp="2010-11-11T14:40:10">
+
+  <imports>
+    <import package="org.iso.otx.examples" document="Signatures" prefix="sig" />
+  </imports>
+
+
+  <procedures>
+    <procedure name="main" visibility="PUBLIC" id="20-p1">
+      <specification>Demonstration of variable, constant and parameter declarations</specification>
+      <realisation>
+        <declarations>
+          <variable name="y" id="20-d1" />
+        </declarations>
+        <flow>
+          <action id="call1">
+            <specification>Calls procedure located in same document</specification>
+            <realisation xsi:type="ProcedureCall" procedure="ComputeDelta">
+              <arguments>
+                <inArg param="a">
+                  <term xsi:type="IntegralLiteral" value="5" />
+                </inArg>
+                <inArg param="b">
+                  <term xsi:type="IntegralValue" valueOf="x" />
+                </inArg>
+                <outArg param="delta">
+                  <variable xsi:type="IntegerVariable" name="d" />
+                </outArg>
+              </arguments>
+            </realisation>
+          </action>
+          <action id="call2">
+            <specification>Calls procedure by an external signature</specification>
+            <realisation xsi:type="ProcedureCall" procedure="sig:modifyValue">
+              <arguments>
+                <inoutArg param="value">
+                  <variable xsi:type="IntegerVariable" name="x" />
+                </inoutArg>
+              </arguments>
+            </realisation>
+          </action>
+        </flow>
+      </realisation>
+    </procedure>
+    <procedure name="computeDelta" id="20-p2">
+      <specification>Computes the difference between two values</specification>
+      <realisation>
+        <parameters>
+          <inParam name="a" id="20-d2" />
+          <inParam name="b" id="20-d3" />
+          <outParam name="delta" id="20-d4" />
+        </parameters>
+        <flow />
+      </realisation>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -561,3 +561,54 @@ def test_chk009_negative_multiple_errors(
     assert core_issues[1].level == IssueSeverity.ERROR
 
     test_utils.cleanup_files()
+
+
+def test_chk010_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk010"
+    target_file_name = f"Core_Chk010_positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_010.unique_node_names"
+    )
+    assert len(core_issues) == 0
+    test_utils.cleanup_files()
+
+
+def test_chk010_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/Core_Chk010"
+    target_file_name = f"Core_Chk010_negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:core.chk_010.unique_node_names"
+    )
+    assert len(core_issues) == 3
+
+    assert "Duplicated name a" in core_issues[0].locations[0].description
+    assert "Duplicated name x" in core_issues[1].locations[0].description
+    assert "Duplicated name b" in core_issues[2].locations[0].description
+
+    assert core_issues[0].level == IssueSeverity.WARNING
+    assert core_issues[1].level == IssueSeverity.WARNING
+    assert core_issues[2].level == IssueSeverity.WARNING
+
+    test_utils.cleanup_files()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -603,8 +603,8 @@ def test_chk010_negative(
     )
     assert len(core_issues) == 3
 
-    assert "Duplicated name a" in core_issues[0].locations[0].description
-    assert "Duplicated name x" in core_issues[1].locations[0].description
+    assert "Duplicated name x" in core_issues[0].locations[0].description
+    assert "Duplicated name a" in core_issues[1].locations[0].description
     assert "Duplicated name b" in core_issues[2].locations[0].description
 
     assert core_issues[0].level == IssueSeverity.WARNING


### PR DESCRIPTION
**Description**
Implement core checker rule Core_Chk010
 Criterion: The value of a nodes name attribute should be unique among all nodes in a procedure.
 Severity: Warning

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.


**Notes**

Verify which attribute between `name` and `id` should be addressed in the check. This is because the following example from the standard

```
<procedure name="main" visibility="PUBLIC" id="20-p1">
      <specification>Demonstration of variable, constant and parameter declarations</specification>
      <realisation>
        <declarations>
          <variable name="x" id="20-d1" />
        </declarations>
        <flow>
          <action id="call2">
            <specification>Calls procedure by an external signature</specification>
            <realisation xsi:type="ProcedureCall" procedure="sig:modifyValue">
              <arguments>
                <inoutArg param="value">
                  <variable xsi:type="IntegerVariable" name="x" />
                </inoutArg>
              </arguments>
            </realisation>
          </action>
        </flow>
      </realisation>
    </procedure>
```

violates this rule as `name=x` appears twice (in declaration and inoutArg)
