### PR TITLE
Add xpath list to unique node rule

### DIFF
--- a/qc_otx/checks/core_checker/unique_node_names.py
+++ b/qc_otx/checks/core_checker/unique_node_names.py
@@ -74,11 +74,6 @@ def check_rule(checker_data: models.CheckerData) -> None:
             if len(xpaths) <= 1:
                 continue
 
-            error_string = f"Duplicated name {name}"
-            for xpath in xpaths:
-                error_string += f" defined at {xpath}"
-
-            current_xpath = xpaths[0]
             issue_id = checker_data.result.register_issue(
                 checker_bundle_name=constants.BUNDLE_NAME,
                 checker_id=core_constants.CHECKER_ID,
@@ -87,10 +82,14 @@ def check_rule(checker_data: models.CheckerData) -> None:
                 rule_uid=rule_uid,
             )
 
+            error_string = f"Duplicated name {name}"
+            for xpath in xpaths:
+                error_string += f" defined at {xpath}"
+
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
                 checker_id=core_constants.CHECKER_ID,
                 issue_id=issue_id,
-                xpath=current_xpath,
-                description=f"Procedure {procedure_name} at {current_xpath} contains duplicated name. {error_string}",
+                xpath=xpaths,
+                description=f"Procedure {procedure_name} at {xpath} contains duplicated name. {error_string}",
             )

--- a/qc_otx/checks/core_checker/unique_node_names.py
+++ b/qc_otx/checks/core_checker/unique_node_names.py
@@ -91,5 +91,5 @@ def check_rule(checker_data: models.CheckerData) -> None:
                 checker_id=core_constants.CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpaths,
-                description=f"Procedure {procedure_name} at {xpath} contains duplicated name. {error_string}",
+                description=f"Procedure {procedure_name} contains duplicated name. {error_string}",
             )

--- a/qc_otx/checks/core_checker/unique_node_names.py
+++ b/qc_otx/checks/core_checker/unique_node_names.py
@@ -82,14 +82,10 @@ def check_rule(checker_data: models.CheckerData) -> None:
                 rule_uid=rule_uid,
             )
 
-            error_string = f"Duplicated name {name}"
-            for xpath in xpaths:
-                error_string += f" defined at {xpath}"
-
             checker_data.result.add_xml_location(
                 checker_bundle_name=constants.BUNDLE_NAME,
                 checker_id=core_constants.CHECKER_ID,
                 issue_id=issue_id,
                 xpath=xpaths,
-                description=f"Procedure {procedure_name} contains duplicated name. {error_string}",
+                description=f"Procedure {procedure_name} contains duplicated name.",
             )

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -603,9 +603,9 @@ def test_chk010_negative(
     )
     assert len(core_issues) == 3
 
-    assert "Duplicated name x" in core_issues[0].locations[0].description
-    assert "Duplicated name a" in core_issues[1].locations[0].description
-    assert "Duplicated name b" in core_issues[2].locations[0].description
+    assert "Procedure main" in core_issues[0].locations[0].description
+    assert "Procedure main" in core_issues[1].locations[0].description
+    assert "Procedure computeDelta" in core_issues[2].locations[0].description
 
     assert core_issues[0].level == IssueSeverity.WARNING
     assert core_issues[1].level == IssueSeverity.WARNING


### PR DESCRIPTION
**Description**

Add list of xml paths for duplicates found in unique node rule

**How was the PR tested?**

1. Unit-test with some  data. All unit tests passed.


**Notes**
example output
```
<Issue issueId="1" description="Issue flagging when nodes with same attribute name are found in a procedure" level="2" ruleUID="asam.net:otx:1.0.0:core.chk_010.unique_node_names">
        <Locations description="Procedure main at /otx/procedures/procedure[1]/realisation/flow/action[2]/realisation/arguments/inoutArg/variable contains duplicated name. Duplicated name x defined at /otx/procedures/procedure[1]/realisation/declarations/variable defined at /otx/procedures/procedure[1]/realisation/flow/action[2]/realisation/arguments/inoutArg/variable">
          <XMLLocation xpath="/otx/procedures/procedure[1]/realisation/declarations/variable"/>
          <XMLLocation xpath="/otx/procedures/procedure[1]/realisation/flow/action[2]/realisation/arguments/inoutArg/variable"/>
        </Locations>
      </Issue>
```
