### PR TITLE
Add first data type check

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from lxml import etree
 from qc_baselib import Configuration, Result
 from qc_otx import constants
 from qc_otx.checks.core_checker import core_checker
+from qc_otx.checks.data_type_checker import data_type_checker
 from qc_otx.checks import utils, models
 
 logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
@@ -56,6 +57,9 @@ def main():
         )
         # 1. Run basic checks
         core_checker.run_checks(checker_data)
+
+        # 2. Run data type checks
+        data_type_checker.run_checks(checker_data)
 
         result.write_to_file(
             config.get_checker_bundle_param(

--- a/qc_otx/checks/data_type_checker/__init__.py
+++ b/qc_otx/checks/data_type_checker/__init__.py
@@ -1,0 +1,3 @@
+from . import data_type_constants as data_type_constants
+from . import data_type_checker as data_type_checker
+from . import accessing_structure_elements as accessing_structure_elements

--- a/qc_otx/checks/data_type_checker/accessing_structure_elements.py
+++ b/qc_otx/checks/data_type_checker/accessing_structure_elements.py
@@ -24,8 +24,6 @@ def check_rule(checker_data: models.CheckerData) -> None:
     Remark:
         None
 
-    More info at
-        -
     """
     logging.info("Executing accessing_structure_elements check")
 

--- a/qc_otx/checks/data_type_checker/accessing_structure_elements.py
+++ b/qc_otx/checks/data_type_checker/accessing_structure_elements.py
@@ -1,0 +1,106 @@
+import logging, os
+
+from typing import List
+
+from lxml import etree
+
+from qc_baselib import Result, IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models
+
+from qc_otx.checks.data_type_checker import data_type_constants
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements
+
+    Description: Accessing structure elements is only allowed via StepByName using matching string literals.
+    Severity: ERROR
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    More info at
+        -
+    """
+    logging.info("Executing accessing_structure_elements check")
+
+    issue_severity = IssueSeverity.ERROR
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=data_type_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="data_type.chk_001.accessing_structure_elements",
+    )
+
+    tree = checker_data.input_file_xml_root
+    root = tree.getroot()
+
+    # Use XPath to find all nodes procedure
+    declaration_nodes = tree.xpath("//declaration")
+    signature_nodes = tree.xpath("//signature")
+
+    signature_dict = dict()
+    for signature in signature_nodes:
+
+        field_list = []
+        fields = signature.xpath(".//*[local-name()='element']")
+        for field in fields:
+            field_list.append(field.get("name"))
+
+        signature_dict[signature.get("name")] = field_list
+
+    logging.debug(f"signature_dict {signature_dict}")
+
+    variable_nodes = tree.xpath("//variable")
+    variable_type_dict = dict()
+    for variable in variable_nodes:
+        variable_type = variable.xpath(".//*[@structureType]")
+        if len(variable_type) == 0:
+            continue
+        variable_type_dict[variable.get("name")] = variable_type[0].get("structureType")
+
+    logging.debug(f"variable_type_dict {variable_type_dict}")
+
+    step_by_name_nodes = tree.xpath("//stepByName")
+
+    for step_by_name_node in step_by_name_nodes:
+        logging.debug(f"step_by_name_node: {step_by_name_node}")
+        current_value = step_by_name_node.get("value")
+
+        current_result = step_by_name_node.getparent().getparent()
+        current_result_name = current_result.get("name")
+        if current_result_name is None:
+            continue
+        logging.debug(f"current_value {current_value}")
+        current_variable_type = variable_type_dict[current_result_name]
+        logging.debug(f"current_variable_type {current_variable_type}")
+
+        has_issue = current_value not in signature_dict[current_variable_type]
+
+        if has_issue:
+            current_xpath = tree.getpath(step_by_name_node)
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=data_type_constants.CHECKER_ID,
+                description="Issue flagging when StepByName node accessing invalid fields",
+                level=issue_severity,
+                rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=data_type_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=current_xpath,
+                description=f"Accessing {current_value} for variable {current_result_name} of type {current_variable_type} is not present in type definition",
+            )

--- a/qc_otx/checks/data_type_checker/accessing_structure_elements.py
+++ b/qc_otx/checks/data_type_checker/accessing_structure_elements.py
@@ -11,8 +11,6 @@ from qc_otx.checks import models
 
 from qc_otx.checks.data_type_checker import data_type_constants
 
-logging.basicConfig(level=logging.DEBUG)
-
 
 def check_rule(checker_data: models.CheckerData) -> None:
     """
@@ -81,9 +79,16 @@ def check_rule(checker_data: models.CheckerData) -> None:
         current_result_name = current_result.get("name")
         if current_result_name is None:
             continue
+
         logging.debug(f"current_value {current_value}")
+        if current_result_name not in variable_type_dict:
+            continue
+
         current_variable_type = variable_type_dict[current_result_name]
         logging.debug(f"current_variable_type {current_variable_type}")
+
+        if current_variable_type not in signature_dict:
+            continue
 
         has_issue = current_value not in signature_dict[current_variable_type]
 

--- a/qc_otx/checks/data_type_checker/data_type_checker.py
+++ b/qc_otx/checks/data_type_checker/data_type_checker.py
@@ -1,0 +1,41 @@
+import logging
+
+from lxml import etree
+
+from qc_baselib import Configuration, Result, StatusType
+
+from qc_otx import constants
+from qc_otx.checks import utils, models
+
+from qc_otx.checks.data_type_checker import (
+    data_type_constants,
+    accessing_structure_elements,
+)
+
+
+def run_checks(checker_data: models.CheckerData) -> None:
+    logging.info("Executing data_type checks")
+
+    checker_data.result.register_checker(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=data_type_constants.CHECKER_ID,
+        description="Check if data_type properties of input file are properly set",
+        summary="",
+    )
+
+    rule_list = [
+        accessing_structure_elements.check_rule,  # Chk001
+    ]
+
+    for rule in rule_list:
+        rule(checker_data=checker_data)
+
+    logging.info(
+        f"Issues found - {checker_data.result.get_checker_issue_count(checker_bundle_name=constants.BUNDLE_NAME, checker_id=data_type_constants.CHECKER_ID)}"
+    )
+
+    checker_data.result.set_checker_status(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=data_type_constants.CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )

--- a/qc_otx/checks/data_type_checker/data_type_constants.py
+++ b/qc_otx/checks/data_type_checker/data_type_constants.py
@@ -1,0 +1,1 @@
+CHECKER_ID = "data_type_otx"

--- a/tests/data/DataType_Chk001/negative.otx
+++ b/tests/data/DataType_Chk001/negative.otx
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx
+  xmlns:dataType="http://iso.org/OTX/1.0.0/DataType"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DataTypesExample"
+  id="toplevel_1d0fe717ed994a2ea5870a14f4229fdd"
+  version="1.0.0.0" timestamp="2017-03-09T06:00:00" package="Examples"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                      http://iso.org/OTX/1.0.0/DataType ../ASAMExtensionInterface/otxIFD_DataType.xsd">
+  <signatures>
+    <signature name="Contact" id="Signature1_ba9e0455b76442608fa347733f54c779">
+      <realisation xsi:type="dataType:StructureSignature">
+        <dataType:elements>
+          <dataType:element name="FirstName"
+            id="DatatypeElementDeclaration1_7a0bf885ce0c40d3b1149363c971ed3e">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="LastName"
+            id="DatatypeElementDeclaration2_e06fcd61df02444bb387562e5abf70b4">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Age"
+            id="DatatypeElementDeclaration3_adca2aef468d4164a4fdf75940e902e9">
+            <realisation>
+              <dataType xsi:type="Integer" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Category"
+            id="DatatypeElementDeclaration4_03fb4d9861474a27bbfac8bbd1fc19e2">
+            <realisation>
+              <dataType xsi:type="dataType:Enumeration" enumerationType="ContactCategories">
+                <dataType:init>Private</dataType:init>
+              </dataType>
+            </realisation>
+          </dataType:element>
+        </dataType:elements>
+      </realisation>
+    </signature>
+    <signature name="ContactCategories" id="Signature2_dd38615b66d4435aba6f0933112bb9af">
+      <realisation xsi:type="dataType:EnumerationSignature">
+        <dataType:elements>
+          <dataType:element name="Business"
+            id="EnumerationElementDeclaration1_70bc5e1fc1c94a15a46355ddc993b088" />
+          <dataType:element name="Private"
+            id="EnumerationElementDeclaration2_ee59e279266349458568b5da5b2960ab" />
+        </dataType:elements>
+      </realisation>
+    </signature>
+  </signatures>
+  <procedures>
+    <procedure name="main" id="id2_1b01991588ef43bdb8e40890bf0bd856" visibility="PUBLIC">
+      <realisation>
+        <declarations>
+          <variable name="Contact1" id="VariableDeclaration1_c1d18e0b0afd417cb654c6198a2fe835">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+          <variable name="Contact2" id="VariableDeclaration2_a3b421e035654e66bf1bb58b886d1bee">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+        </declarations>
+        <flow>
+          <action name="Assignment1" id="Assignment_6dd484f2e11d4a7cb9d17b97a3338573">
+            <specification>Assignment of string literal to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Mr." />
+            </realisation>
+          </action>
+          <action name="Assignment2" id="Assignment_a79fb06c726e4142a593529b8b1d376d">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <!-- Inserted rule violation here, value Surname not defined-->
+                  <stepByName xsi:type="StringLiteral" value="Surname" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Bean" />
+            </realisation>
+          </action>
+          <action name="Assignment3" id="Assignment_b599bafe02234deda75c6e7466f29cc5">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerLiteral" value="42" />
+            </realisation>
+          </action>
+          <action name="Assignment4" id="Assignment_055ee4a3dd1043a69808b9c1fea62023">
+            <specification>Assignment of enumeration element to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationLiteral" enumeration="ContactCategories"
+                elementName="Business" />
+            </realisation>
+          </action>
+          <action name="Assignment5" id="Assignment_a20c1df24e3b43ffadb7eea8e1982052">
+            <specification>Assignment of structure element to another structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment6" id="Assignment_59e5caa3c14d4c32b194907ecd421bcd">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment7" id="Assignment_f67e1d83941546ed9b01dec9b36de18f">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment8" id="Assignment_27c5c43232814bb195e83b2614cc0c07">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationValue" valueOf="Contact1">
+                <dataType:path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </dataType:path>
+              </term>
+            </realisation>
+          </action>
+        </flow>
+      </realisation>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/data/DataType_Chk001/positive.otx
+++ b/tests/data/DataType_Chk001/positive.otx
@@ -1,0 +1,173 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx
+  xmlns:dataType="http://iso.org/OTX/1.0.0/DataType"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DataTypesExample"
+  id="toplevel_1d0fe717ed994a2ea5870a14f4229fdd"
+  version="1.0.0.0" timestamp="2017-03-09T06:00:00" package="Examples"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                      http://iso.org/OTX/1.0.0/DataType ../ASAMExtensionInterface/otxIFD_DataType.xsd">
+  <signatures>
+    <signature name="Contact" id="Signature1_ba9e0455b76442608fa347733f54c779">
+      <realisation xsi:type="dataType:StructureSignature">
+        <dataType:elements>
+          <dataType:element name="FirstName"
+            id="DatatypeElementDeclaration1_7a0bf885ce0c40d3b1149363c971ed3e">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="LastName"
+            id="DatatypeElementDeclaration2_e06fcd61df02444bb387562e5abf70b4">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Age"
+            id="DatatypeElementDeclaration3_adca2aef468d4164a4fdf75940e902e9">
+            <realisation>
+              <dataType xsi:type="Integer" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Category"
+            id="DatatypeElementDeclaration4_03fb4d9861474a27bbfac8bbd1fc19e2">
+            <realisation>
+              <dataType xsi:type="dataType:Enumeration" enumerationType="ContactCategories">
+                <dataType:init>Private</dataType:init>
+              </dataType>
+            </realisation>
+          </dataType:element>
+        </dataType:elements>
+      </realisation>
+    </signature>
+    <signature name="ContactCategories" id="Signature2_dd38615b66d4435aba6f0933112bb9af">
+      <realisation xsi:type="dataType:EnumerationSignature">
+        <dataType:elements>
+          <dataType:element name="Business"
+            id="EnumerationElementDeclaration1_70bc5e1fc1c94a15a46355ddc993b088" />
+          <dataType:element name="Private"
+            id="EnumerationElementDeclaration2_ee59e279266349458568b5da5b2960ab" />
+        </dataType:elements>
+      </realisation>
+    </signature>
+  </signatures>
+  <procedures>
+    <procedure name="main" id="id2_1b01991588ef43bdb8e40890bf0bd856" visibility="PUBLIC">
+      <realisation>
+        <declarations>
+          <variable name="Contact1" id="VariableDeclaration1_c1d18e0b0afd417cb654c6198a2fe835">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+          <variable name="Contact2" id="VariableDeclaration2_a3b421e035654e66bf1bb58b886d1bee">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+        </declarations>
+        <flow>
+          <action name="Assignment1" id="Assignment_6dd484f2e11d4a7cb9d17b97a3338573">
+            <specification>Assignment of string literal to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Mr." />
+            </realisation>
+          </action>
+          <action name="Assignment2" id="Assignment_a79fb06c726e4142a593529b8b1d376d">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Bean" />
+            </realisation>
+          </action>
+          <action name="Assignment3" id="Assignment_b599bafe02234deda75c6e7466f29cc5">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerLiteral" value="42" />
+            </realisation>
+          </action>
+          <action name="Assignment4" id="Assignment_055ee4a3dd1043a69808b9c1fea62023">
+            <specification>Assignment of enumeration element to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationLiteral" enumeration="ContactCategories"
+                elementName="Business" />
+            </realisation>
+          </action>
+          <action name="Assignment5" id="Assignment_a20c1df24e3b43ffadb7eea8e1982052">
+            <specification>Assignment of structure element to another structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment6" id="Assignment_59e5caa3c14d4c32b194907ecd421bcd">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment7" id="Assignment_f67e1d83941546ed9b01dec9b36de18f">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment8" id="Assignment_27c5c43232814bb195e83b2614cc0c07">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationValue" valueOf="Contact1">
+                <dataType:path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </dataType:path>
+              </term>
+            </realisation>
+          </action>
+        </flow>
+      </realisation>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/test_data_type_checks.py
+++ b/tests/test_data_type_checks.py
@@ -1,0 +1,55 @@
+import os
+import pytest
+import test_utils
+from qc_otx import constants
+from qc_otx.checks.core_checker import core_constants
+from qc_baselib import Result, IssueSeverity
+
+
+def test_chk001_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/DataType_Chk001/"
+    target_file_name = f"positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk001_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/DataType_Chk001/"
+    target_file_name = f"negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    core_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements"
+    )
+    assert len(core_issues) == 1
+    assert core_issues[0].level == IssueSeverity.ERROR
+
+    test_utils.cleanup_files()


### PR DESCRIPTION
**Description**

Add first data type check

A.2.3.1. DataType_Chk001 – Accessing structure elements
Severity: Critical
Criterion: Accessing structure elements is only allowed via StepByName using matching string literals.

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.


**Notes**
Example out
```
<Checker status="completed" checkerId="data_type_otx" description="Check if data_type properties of input file are properly set" summary="">
      <AddressedRule ruleUID="asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements"/>
      <Issue issueId="3" description="Issue flagging when StepByName node accessing invalid fields" level="1" ruleUID="asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements">
        <Locations description="Accessing Surname for variable Contact1 of type Contact is not present in type definition">
          <XMLLocation xpath="/otx/procedures/procedure/realisation/flow/action[2]/realisation/result/path/stepByName"/>
        </Locations>
      </Issue>
    </Checker>
```
