### PR TITLE
Add data type check 008 implementation

### DIFF
--- a/qc_otx/checks/data_type_checker/__init__.py
+++ b/qc_otx/checks/data_type_checker/__init__.py
@@ -1,3 +1,6 @@
 from . import data_type_constants as data_type_constants
 from . import data_type_checker as data_type_checker
 from . import accessing_structure_elements as accessing_structure_elements
+from . import (
+    correct_target_for_structure_element as correct_target_for_structure_element,
+)

--- a/qc_otx/checks/data_type_checker/correct_target_for_structure_element.py
+++ b/qc_otx/checks/data_type_checker/correct_target_for_structure_element.py
@@ -7,8 +7,6 @@ from qc_otx.checks import models
 
 from qc_otx.checks.data_type_checker import data_type_constants
 
-logging.basicConfig(level=logging.DEBUG)
-
 
 def check_rule(checker_data: models.CheckerData) -> None:
     """

--- a/qc_otx/checks/data_type_checker/correct_target_for_structure_element.py
+++ b/qc_otx/checks/data_type_checker/correct_target_for_structure_element.py
@@ -1,0 +1,105 @@
+import logging
+
+from qc_baselib import IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models
+
+from qc_otx.checks.data_type_checker import data_type_constants
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element
+
+    Description: When referring to a structure element, an existing <element> name of the referenced StructureSignature shall be used.
+    Severity: ERROR
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    """
+    logging.info("Executing correct_target_for_structure_element check")
+
+    issue_severity = IssueSeverity.ERROR
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=data_type_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="data_type.chk_008.correct_target_for_structure_element",
+    )
+
+    tree = checker_data.input_file_xml_root
+    root = tree.getroot()
+
+    # Use XPath to find all nodes procedure
+    declaration_nodes = tree.xpath("//declaration")
+    signature_nodes = tree.xpath("//signature")
+
+    signature_dict = dict()
+    for signature in signature_nodes:
+
+        field_list = []
+        fields = signature.xpath(".//*[local-name()='element']")
+        for field in fields:
+            field_list.append(field.get("name"))
+
+        signature_dict[signature.get("name")] = field_list
+
+    logging.debug(f"signature_dict {signature_dict}")
+
+    variable_nodes = tree.xpath("//variable")
+    variable_type_dict = dict()
+    for variable in variable_nodes:
+        variable_type = variable.xpath(".//*[@structureType]")
+        if len(variable_type) == 0:
+            continue
+        variable_type_dict[variable.get("name")] = variable_type[0].get("structureType")
+
+    logging.debug(f"variable_type_dict {variable_type_dict}")
+
+    for structure_name in variable_type_dict.keys():
+        logging.debug(f"structure_name: {structure_name}")
+
+        structure_instances = tree.xpath(f"//*[@name='{structure_name}']")
+
+        logging.debug(f"structure_instances: {structure_instances}")
+
+        for structure_instance in structure_instances:
+            structure_accesses = structure_instance.xpath(".//*[@value]")
+
+            for structure_access in structure_accesses:
+                current_value = structure_access.get("value")
+                if current_value is None:
+                    continue
+                logging.debug(f"current_value: {current_value}")
+
+                current_variable_type = variable_type_dict[structure_name]
+                logging.debug(f"current_variable_type: {current_variable_type}")
+
+                has_issue = current_value not in signature_dict[current_variable_type]
+
+                if has_issue:
+                    current_xpath = tree.getpath(structure_instance)
+                    issue_id = checker_data.result.register_issue(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=data_type_constants.CHECKER_ID,
+                        description="Issue flagging when invalid names is used in accessing structure element",
+                        level=issue_severity,
+                        rule_uid=rule_uid,
+                    )
+
+                    checker_data.result.add_xml_location(
+                        checker_bundle_name=constants.BUNDLE_NAME,
+                        checker_id=data_type_constants.CHECKER_ID,
+                        issue_id=issue_id,
+                        xpath=current_xpath,
+                        description=f"Accessing {current_value} for variable {structure_name} of type {current_variable_type} is not present in type definition",
+                    )

--- a/qc_otx/checks/data_type_checker/data_type_checker.py
+++ b/qc_otx/checks/data_type_checker/data_type_checker.py
@@ -10,6 +10,7 @@ from qc_otx.checks import utils, models
 from qc_otx.checks.data_type_checker import (
     data_type_constants,
     accessing_structure_elements,
+    correct_target_for_structure_element,
 )
 
 
@@ -25,6 +26,7 @@ def run_checks(checker_data: models.CheckerData) -> None:
 
     rule_list = [
         accessing_structure_elements.check_rule,  # Chk001
+        correct_target_for_structure_element.check_rule,  # Chk008
     ]
 
     for rule in rule_list:

--- a/tests/data/DataType_Chk008/negative.otx
+++ b/tests/data/DataType_Chk008/negative.otx
@@ -1,0 +1,176 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx
+  xmlns:dataType="http://iso.org/OTX/1.0.0/DataType"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DataTypesExample"
+  id="toplevel_1d0fe717ed994a2ea5870a14f4229fdd"
+  version="1.0.0.0" timestamp="2017-03-09T06:00:00" package="Examples"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                      http://iso.org/OTX/1.0.0/DataType ../ASAMExtensionInterface/otxIFD_DataType.xsd">
+  <signatures>
+    <signature name="Contact" id="Signature1_ba9e0455b76442608fa347733f54c779">
+      <realisation xsi:type="dataType:StructureSignature">
+        <dataType:elements>
+          <dataType:element name="FirstName"
+            id="DatatypeElementDeclaration1_7a0bf885ce0c40d3b1149363c971ed3e">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="LastName"
+            id="DatatypeElementDeclaration2_e06fcd61df02444bb387562e5abf70b4">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Age"
+            id="DatatypeElementDeclaration3_adca2aef468d4164a4fdf75940e902e9">
+            <realisation>
+              <dataType xsi:type="Integer" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Category"
+            id="DatatypeElementDeclaration4_03fb4d9861474a27bbfac8bbd1fc19e2">
+            <realisation>
+              <dataType xsi:type="dataType:Enumeration" enumerationType="ContactCategories">
+                <dataType:init>Private</dataType:init>
+              </dataType>
+            </realisation>
+          </dataType:element>
+        </dataType:elements>
+      </realisation>
+    </signature>
+    <signature name="ContactCategories" id="Signature2_dd38615b66d4435aba6f0933112bb9af">
+      <realisation xsi:type="dataType:EnumerationSignature">
+        <dataType:elements>
+          <dataType:element name="Business"
+            id="EnumerationElementDeclaration1_70bc5e1fc1c94a15a46355ddc993b088" />
+          <dataType:element name="Private"
+            id="EnumerationElementDeclaration2_ee59e279266349458568b5da5b2960ab" />
+        </dataType:elements>
+      </realisation>
+    </signature>
+  </signatures>
+  <procedures>
+    <procedure name="main" id="id2_1b01991588ef43bdb8e40890bf0bd856" visibility="PUBLIC">
+      <realisation>
+        <declarations>
+          <variable name="Contact1" id="VariableDeclaration1_c1d18e0b0afd417cb654c6198a2fe835">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+          <variable name="Contact2" id="VariableDeclaration2_a3b421e035654e66bf1bb58b886d1bee">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+        </declarations>
+        <flow>
+          <action name="Assignment1" id="Assignment_6dd484f2e11d4a7cb9d17b97a3338573">
+            <specification>Assignment of string literal to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <!-- Inserted rule violation here. MainName not present in structure signature-->
+                  <path_instance xsi:type="StringLiteral" value="MainName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Mr." />
+            </realisation>
+          </action>
+          <action name="Assignment2" id="Assignment_a79fb06c726e4142a593529b8b1d376d">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Bean" />
+            </realisation>
+          </action>
+          <action name="Assignment3" id="Assignment_b599bafe02234deda75c6e7466f29cc5">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerLiteral" value="42" />
+            </realisation>
+          </action>
+          <action name="Assignment4" id="Assignment_055ee4a3dd1043a69808b9c1fea62023">
+            <specification>Assignment of enumeration element to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationLiteral" enumeration="ContactCategories"
+                elementName="Business" />
+            </realisation>
+          </action>
+          <action name="Assignment5" id="Assignment_a20c1df24e3b43ffadb7eea8e1982052">
+            <specification>Assignment of structure element to another structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment6" id="Assignment_59e5caa3c14d4c32b194907ecd421bcd">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment7" id="Assignment_f67e1d83941546ed9b01dec9b36de18f">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact2">
+                <path>
+                  <!-- Inserted rule violation here. DateOfBirth not present in structure
+                  signature-->
+                  <path_instance xsi:type="StringLiteral" value="DateOfBirth" />
+                </path>
+              </result>
+              <term xsi:type="IntegerValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment8" id="Assignment_27c5c43232814bb195e83b2614cc0c07">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationValue" valueOf="Contact1">
+                <dataType:path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </dataType:path>
+              </term>
+            </realisation>
+          </action>
+        </flow>
+      </realisation>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/data/DataType_Chk008/positive.otx
+++ b/tests/data/DataType_Chk008/positive.otx
@@ -1,0 +1,173 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx
+  xmlns:dataType="http://iso.org/OTX/1.0.0/DataType"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DataTypesExample"
+  id="toplevel_1d0fe717ed994a2ea5870a14f4229fdd"
+  version="1.0.0.0" timestamp="2017-03-09T06:00:00" package="Examples"
+  xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                      http://iso.org/OTX/1.0.0/DataType ../ASAMExtensionInterface/otxIFD_DataType.xsd">
+  <signatures>
+    <signature name="Contact" id="Signature1_ba9e0455b76442608fa347733f54c779">
+      <realisation xsi:type="dataType:StructureSignature">
+        <dataType:elements>
+          <dataType:element name="FirstName"
+            id="DatatypeElementDeclaration1_7a0bf885ce0c40d3b1149363c971ed3e">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="LastName"
+            id="DatatypeElementDeclaration2_e06fcd61df02444bb387562e5abf70b4">
+            <realisation>
+              <dataType xsi:type="String" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Age"
+            id="DatatypeElementDeclaration3_adca2aef468d4164a4fdf75940e902e9">
+            <realisation>
+              <dataType xsi:type="Integer" />
+            </realisation>
+          </dataType:element>
+          <dataType:element name="Category"
+            id="DatatypeElementDeclaration4_03fb4d9861474a27bbfac8bbd1fc19e2">
+            <realisation>
+              <dataType xsi:type="dataType:Enumeration" enumerationType="ContactCategories">
+                <dataType:init>Private</dataType:init>
+              </dataType>
+            </realisation>
+          </dataType:element>
+        </dataType:elements>
+      </realisation>
+    </signature>
+    <signature name="ContactCategories" id="Signature2_dd38615b66d4435aba6f0933112bb9af">
+      <realisation xsi:type="dataType:EnumerationSignature">
+        <dataType:elements>
+          <dataType:element name="Business"
+            id="EnumerationElementDeclaration1_70bc5e1fc1c94a15a46355ddc993b088" />
+          <dataType:element name="Private"
+            id="EnumerationElementDeclaration2_ee59e279266349458568b5da5b2960ab" />
+        </dataType:elements>
+      </realisation>
+    </signature>
+  </signatures>
+  <procedures>
+    <procedure name="main" id="id2_1b01991588ef43bdb8e40890bf0bd856" visibility="PUBLIC">
+      <realisation>
+        <declarations>
+          <variable name="Contact1" id="VariableDeclaration1_c1d18e0b0afd417cb654c6198a2fe835">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+          <variable name="Contact2" id="VariableDeclaration2_a3b421e035654e66bf1bb58b886d1bee">
+            <realisation>
+              <dataType xsi:type="dataType:Structure" structureType="Contact" />
+            </realisation>
+          </variable>
+        </declarations>
+        <flow>
+          <action name="Assignment1" id="Assignment_6dd484f2e11d4a7cb9d17b97a3338573">
+            <specification>Assignment of string literal to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Mr." />
+            </realisation>
+          </action>
+          <action name="Assignment2" id="Assignment_a79fb06c726e4142a593529b8b1d376d">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringLiteral" value="Bean" />
+            </realisation>
+          </action>
+          <action name="Assignment3" id="Assignment_b599bafe02234deda75c6e7466f29cc5">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerLiteral" value="42" />
+            </realisation>
+          </action>
+          <action name="Assignment4" id="Assignment_055ee4a3dd1043a69808b9c1fea62023">
+            <specification>Assignment of enumeration element to structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationLiteral" enumeration="ContactCategories"
+                elementName="Business" />
+            </realisation>
+          </action>
+          <action name="Assignment5" id="Assignment_a20c1df24e3b43ffadb7eea8e1982052">
+            <specification>Assignment of structure element to another structure element</specification>
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="FirstName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment6" id="Assignment_59e5caa3c14d4c32b194907ecd421bcd">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="StringVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </result>
+              <term xsi:type="StringValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="LastName" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment7" id="Assignment_f67e1d83941546ed9b01dec9b36de18f">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="IntegerVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </result>
+              <term xsi:type="IntegerValue" valueOf="Contact1">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Age" />
+                </path>
+              </term>
+            </realisation>
+          </action>
+          <action name="Assignment8" id="Assignment_27c5c43232814bb195e83b2614cc0c07">
+            <realisation xsi:type="Assignment">
+              <result xsi:type="dataType:EnumerationVariable" name="Contact2">
+                <path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </path>
+              </result>
+              <term xsi:type="dataType:EnumerationValue" valueOf="Contact1">
+                <dataType:path>
+                  <stepByName xsi:type="StringLiteral" value="Category" />
+                </dataType:path>
+              </term>
+            </realisation>
+          </action>
+        </flow>
+      </realisation>
+    </procedure>
+  </procedures>
+</otx>

--- a/tests/test_data_type_checks.py
+++ b/tests/test_data_type_checks.py
@@ -46,10 +46,62 @@ def test_chk001_negative(
     result = Result()
     result.load_from_file(test_utils.REPORT_FILE_PATH)
 
-    core_issues = result.get_issues_by_rule_uid(
+    data_type_issues = result.get_issues_by_rule_uid(
         "asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements"
     )
-    assert len(core_issues) == 1
-    assert core_issues[0].level == IssueSeverity.ERROR
+    assert len(data_type_issues) == 1
+    assert data_type_issues[0].level == IssueSeverity.ERROR
+
+    test_utils.cleanup_files()
+
+
+def test_chk008_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/DataType_Chk008/"
+    target_file_name = f"positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk008_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/DataType_Chk008/"
+    target_file_name = f"negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    data_type_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element"
+    )
+    assert len(data_type_issues) == 2
+    assert data_type_issues[0].level == IssueSeverity.ERROR
+    assert data_type_issues[1].level == IssueSeverity.ERROR
+    assert "MainName" in data_type_issues[0].locations[0].description
+    assert "DateOfBirth" in data_type_issues[1].locations[0].description
 
     test_utils.cleanup_files()


### PR DESCRIPTION
**Description**

Add data type check 008 implementation and test code

Rule info
```
Rule ID: asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element

    Description: When referring to a structure element, an existing <element> name of the referenced StructureSignature shall be used.
    Severity: ERROR

    Version range: [1.0.0, )
```

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.

**Notes**
example output
```
<Checker status="completed" checkerId="data_type_otx" description="Check if data_type properties of input file are properly set" summary="">
      <AddressedRule ruleUID="asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements"/>
      <AddressedRule ruleUID="asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element"/>
      <Issue issueId="3" description="Issue flagging when invalid names is used in accessing structure element" level="1" ruleUID="asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element">
        <Locations description="Accessing MainName for variable Contact1 of type Contact is not present in type definition">
          <XMLLocation xpath="/otx/procedures/procedure/realisation/flow/action[1]/realisation/result"/>
        </Locations>
      </Issue>
      <Issue issueId="4" description="Issue flagging when invalid names is used in accessing structure element" level="1" ruleUID="asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element">
        <Locations description="Accessing DateOfBirth for variable Contact2 of type Contact is not present in type definition">
          <XMLLocation xpath="/otx/procedures/procedure/realisation/flow/action[7]/realisation/result"/>
        </Locations>
      </Issue>
    </Checker>
```