### PR TITLE
Add mandatory fields checks

### DIFF
--- a/qc_otx/checks/state_machine_checker/__init__.py
+++ b/qc_otx/checks/state_machine_checker/__init__.py
@@ -5,3 +5,6 @@ from . import mandatory_target_state as mandatory_target_state
 from . import no_target_state_for_completed_state as no_target_state_for_completed_state
 from . import mandatory_transition as mandatory_transition
 from . import mandatory_trigger as mandatory_trigger
+from . import (
+    distinguished_initial_and_completed_state as distinguished_initial_and_completed_state,
+)

--- a/qc_otx/checks/state_machine_checker/__init__.py
+++ b/qc_otx/checks/state_machine_checker/__init__.py
@@ -2,3 +2,6 @@ from . import state_machine_constants as state_machine_constants
 from . import state_machine_checker as state_machine_checker
 from . import no_procedure_realization as no_procedure_realization
 from . import mandatory_target_state as mandatory_target_state
+from . import no_target_state_for_completed_state as no_target_state_for_completed_state
+from . import mandatory_transition as mandatory_transition
+from . import mandatory_trigger as mandatory_trigger

--- a/qc_otx/checks/state_machine_checker/distinguished_initial_and_completed_state.py
+++ b/qc_otx/checks/state_machine_checker/distinguished_initial_and_completed_state.py
@@ -12,7 +12,7 @@ def check_rule(checker_data: models.CheckerData) -> None:
     """
     Rule ID: asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state
 
-    Description: Each state except the completed state shall have a target state.
+    Description: The values of the mandatory initialState and optional completedState attributes shall be distinguished.
     Severity: ERROR
 
     Version range: [1.0.0, )

--- a/qc_otx/checks/state_machine_checker/distinguished_initial_and_completed_state.py
+++ b/qc_otx/checks/state_machine_checker/distinguished_initial_and_completed_state.py
@@ -1,0 +1,93 @@
+import logging
+
+from qc_baselib import IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models, utils
+
+from qc_otx.checks.state_machine_checker import state_machine_constants
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state
+
+    Description: Each state except the completed state shall have a target state.
+    Severity: ERROR
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    """
+    logging.info("Executing distinguished_initial_and_completed_state check")
+
+    issue_severity = IssueSeverity.ERROR
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=state_machine_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="state_machine.chk_006.distinguished_initial_and_completed_state",
+    )
+
+    tree = checker_data.input_file_xml_root
+    nsmap = utils.get_namespace_map(tree)
+
+    if "smp" not in nsmap:
+        logging.error(
+            'No state machine procedure prefix "smp" found in document namespaces. Abort state machine procedure checks...'
+        )
+        return
+
+    state_machine_procedures = utils.get_state_machine_procedures(tree, nsmap)
+
+    if state_machine_procedures is None:
+        return
+
+    logging.debug(f"state_machine_procedures: {state_machine_procedures}")
+
+    # smp = "state machine procedure"
+    for state_machine_procedure in state_machine_procedures:
+
+        state_machine = utils.get_state_machine(state_machine_procedure, nsmap)
+
+        if state_machine is None:
+            return
+
+        smp_realisation = state_machine_procedure.xpath(
+            "./smp:realisation", namespaces=nsmap
+        )
+        logging.debug(f"smp_realisation: {smp_realisation}")
+
+        if smp_realisation is None or len(smp_realisation) != 1:
+            logging.error(
+                f"Invalid realisation found in current state machine procedure"
+            )
+            return
+
+        smp_realisation = smp_realisation[0]
+
+        has_issue = smp_realisation.get("initialState") == smp_realisation.get(
+            "completedState"
+        )
+        if has_issue:
+            current_xpath = tree.getelementpath(smp_realisation)
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=state_machine_constants.CHECKER_ID,
+                description="Issue flagging when initialState and completedState cannot be distinguished",
+                level=issue_severity,
+                rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=state_machine_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=current_xpath,
+                description=f"State machine realisation cannot distinguish between initial and completed state",
+            )

--- a/qc_otx/checks/state_machine_checker/mandatory_transition.py
+++ b/qc_otx/checks/state_machine_checker/mandatory_transition.py
@@ -1,0 +1,79 @@
+import logging
+
+from qc_baselib import IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models, utils
+
+from qc_otx.checks.state_machine_checker import state_machine_constants
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:otx:1.0.0:state_machine.chk_005.mandatory_transition
+
+    Criterion: Each state except the completed state shall have at least one transition.
+    Severity: Critical
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    """
+    logging.info("Executing mandatory_transition check")
+
+    issue_severity = IssueSeverity.ERROR
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=state_machine_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="state_machine.chk_005.mandatory_transition",
+    )
+
+    tree = checker_data.input_file_xml_root
+    nsmap = utils.get_namespace_map(tree)
+
+    if "smp" not in nsmap:
+        logging.error(
+            'No state machine procedure prefix "smp" found in document namespaces. Abort state machine procedure checks...'
+        )
+        return
+
+    state_machine_procedures = utils.get_state_machine_procedures(tree, nsmap)
+
+    if state_machine_procedures is None:
+        return
+
+    logging.debug(f"state_machine_procedures: {state_machine_procedures}")
+
+    # smp = "state machine procedure"
+    for state_machine_procedure in state_machine_procedures:
+
+        state_machine = utils.get_state_machine(state_machine_procedure, nsmap)
+
+        if state_machine is None:
+            return
+
+        for sm_state in state_machine.states:
+            has_issue = not sm_state.is_completed and len(sm_state.transitions) == 0
+            if has_issue:
+                current_xpath = tree.getelementpath(sm_state.xml_element)
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=state_machine_constants.CHECKER_ID,
+                    description="Issue flagging when a non completed state has no transition",
+                    level=issue_severity,
+                    rule_uid=rule_uid,
+                )
+
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=state_machine_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=current_xpath,
+                    description=f"State {sm_state.name} with id {sm_state.id} does not have any transition",
+                )

--- a/qc_otx/checks/state_machine_checker/mandatory_trigger.py
+++ b/qc_otx/checks/state_machine_checker/mandatory_trigger.py
@@ -1,0 +1,79 @@
+import logging
+
+from qc_baselib import IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models, utils
+
+from qc_otx.checks.state_machine_checker import state_machine_constants
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:otx:1.0.0:state_machine.chk_004.mandatory_trigger
+
+    Criterion: Each state except the completed state shall have at least one trigger.
+    Severity: Critical
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    """
+    logging.info("Executing mandatory_trigger check")
+
+    issue_severity = IssueSeverity.ERROR
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=state_machine_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="state_machine.chk_004.mandatory_trigger",
+    )
+
+    tree = checker_data.input_file_xml_root
+    nsmap = utils.get_namespace_map(tree)
+
+    if "smp" not in nsmap:
+        logging.error(
+            'No state machine procedure prefix "smp" found in document namespaces. Abort state machine procedure checks...'
+        )
+        return
+
+    state_machine_procedures = utils.get_state_machine_procedures(tree, nsmap)
+
+    if state_machine_procedures is None:
+        return
+
+    logging.debug(f"state_machine_procedures: {state_machine_procedures}")
+
+    # smp = "state machine procedure"
+    for state_machine_procedure in state_machine_procedures:
+
+        state_machine = utils.get_state_machine(state_machine_procedure, nsmap)
+
+        if state_machine is None:
+            return
+
+        for sm_state in state_machine.states:
+            has_issue = not sm_state.is_completed and len(sm_state.triggers) == 0
+            if has_issue:
+                current_xpath = tree.getelementpath(sm_state.xml_element)
+                issue_id = checker_data.result.register_issue(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=state_machine_constants.CHECKER_ID,
+                    description="Issue flagging when a non completed state has no triggers",
+                    level=issue_severity,
+                    rule_uid=rule_uid,
+                )
+
+                checker_data.result.add_xml_location(
+                    checker_bundle_name=constants.BUNDLE_NAME,
+                    checker_id=state_machine_constants.CHECKER_ID,
+                    issue_id=issue_id,
+                    xpath=current_xpath,
+                    description=f"State {sm_state.name} with id {sm_state.id} does not have any trigger",
+                )

--- a/qc_otx/checks/state_machine_checker/no_target_state_for_completed_state.py
+++ b/qc_otx/checks/state_machine_checker/no_target_state_for_completed_state.py
@@ -1,0 +1,88 @@
+import logging
+
+from qc_baselib import IssueSeverity
+
+from qc_otx import constants
+from qc_otx.checks import models, utils
+
+from qc_otx.checks.state_machine_checker import state_machine_constants
+
+
+def check_rule(checker_data: models.CheckerData) -> None:
+    """
+    Rule ID: asam.net:otx:1.0.0:state_machine.chk_003.no_target_state_for_completed_state
+
+    Criterion: After finishing the completed state the procedure is finished and shall return to
+    the caller. Therefore the completed state shall not have a target state.
+    Severity: Warning
+
+    Version range: [1.0.0, )
+
+    Remark:
+        None
+
+    """
+    logging.info("Executing no_target_state_for_completed_state check")
+
+    issue_severity = IssueSeverity.WARNING
+
+    rule_uid = checker_data.result.register_rule(
+        checker_bundle_name=constants.BUNDLE_NAME,
+        checker_id=state_machine_constants.CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="otx",
+        definition_setting="1.0.0",
+        rule_full_name="state_machine.chk_003.no_target_state_for_completed_state",
+    )
+
+    tree = checker_data.input_file_xml_root
+    nsmap = utils.get_namespace_map(tree)
+
+    if "smp" not in nsmap:
+        logging.error(
+            'No state machine procedure prefix "smp" found in document namespaces. Abort state machine procedure checks...'
+        )
+        return
+
+    state_machine_procedures = utils.get_state_machine_procedures(tree, nsmap)
+
+    if state_machine_procedures is None:
+        return
+
+    logging.debug(f"state_machine_procedures: {state_machine_procedures}")
+
+    # smp = "state machine procedure"
+    for state_machine_procedure in state_machine_procedures:
+
+        state_machine = utils.get_state_machine(state_machine_procedure, nsmap)
+
+        if state_machine is None:
+            return
+
+        completed_state = None
+        for sm_state in state_machine.states:
+            if sm_state.is_completed:
+                completed_state = sm_state
+                break
+
+        if completed_state is None:
+            return
+
+        has_issue = len(completed_state.target_state_ids) != 0
+        if has_issue:
+            current_xpath = tree.getelementpath(completed_state.xml_element)
+            issue_id = checker_data.result.register_issue(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=state_machine_constants.CHECKER_ID,
+                description="Issue flagging when a completed state has a target state",
+                level=issue_severity,
+                rule_uid=rule_uid,
+            )
+
+            checker_data.result.add_xml_location(
+                checker_bundle_name=constants.BUNDLE_NAME,
+                checker_id=state_machine_constants.CHECKER_ID,
+                issue_id=issue_id,
+                xpath=current_xpath,
+                description=f"Completed state {completed_state.name} with id {completed_state.id} has a target state but it should not",
+            )

--- a/qc_otx/checks/state_machine_checker/state_machine_checker.py
+++ b/qc_otx/checks/state_machine_checker/state_machine_checker.py
@@ -11,6 +11,9 @@ from qc_otx.checks.state_machine_checker import (
     state_machine_constants,
     no_procedure_realization,
     mandatory_target_state,
+    no_target_state_for_completed_state,
+    mandatory_transition,
+    mandatory_trigger,
 )
 
 
@@ -27,6 +30,9 @@ def run_checks(checker_data: models.CheckerData) -> None:
     rule_list = [
         no_procedure_realization.check_rule,  # Chk001
         mandatory_target_state.check_rule,  # Chk002
+        no_target_state_for_completed_state.check_rule,  # Chk003
+        mandatory_transition.check_rule,  # Chk004
+        mandatory_trigger.check_rule,  # Chk005
     ]
 
     for rule in rule_list:

--- a/qc_otx/checks/state_machine_checker/state_machine_checker.py
+++ b/qc_otx/checks/state_machine_checker/state_machine_checker.py
@@ -14,6 +14,7 @@ from qc_otx.checks.state_machine_checker import (
     no_target_state_for_completed_state,
     mandatory_transition,
     mandatory_trigger,
+    distinguished_initial_and_completed_state,
 )
 
 
@@ -33,6 +34,7 @@ def run_checks(checker_data: models.CheckerData) -> None:
         no_target_state_for_completed_state.check_rule,  # Chk003
         mandatory_transition.check_rule,  # Chk004
         mandatory_trigger.check_rule,  # Chk005
+        distinguished_initial_and_completed_state.check_rule,  # Chk006
     ]
 
     for rule in rule_list:

--- a/tests/data/StateMachine_Chk003/negative.otx
+++ b/tests/data/StateMachine_Chk003/negative.otx
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <!-- Inserted rule vtiolation here as completed state has a transition with
+                        a target defined-->
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk003/positive.otx
+++ b/tests/data/StateMachine_Chk003/positive.otx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk004/negative.otx
+++ b/tests/data/StateMachine_Chk004/negative.otx
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <!-- Inserted rule violation here as initial state has no trigger-->
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk004/positive.otx
+++ b/tests/data/StateMachine_Chk004/positive.otx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk005/negative.otx
+++ b/tests/data/StateMachine_Chk005/negative.otx
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <!-- Inserted rule violation here as initial state has no transition-->
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk005/positive.otx
+++ b/tests/data/StateMachine_Chk005/positive.otx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk006/negative.otx
+++ b/tests/data/StateMachine_Chk006/negative.otx
@@ -50,6 +50,8 @@
             id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
             visibility="PUBLIC">
             <specification>This is a new state machine procedure</specification>
+            <!-- Inserted rule violation here as initialState and completedState cannot be
+            distinguised-->
             <smp:realisation initialState="MyInitialState" completedState="MyInitialState">
                 <smp:parameters>
                     <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"

--- a/tests/data/StateMachine_Chk006/negative.otx
+++ b/tests/data/StateMachine_Chk006/negative.otx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyInitialState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk006/positive.otx
+++ b/tests/data/StateMachine_Chk006/positive.otx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState" completedState="MyCompletedState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f023" name="MyCompletedState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_9e22079d28744d37bc6a03044eaf5378"
+                                name="ConfirmDialog3">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Completed" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                    </smp:state>
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/data/StateMachine_Chk006/positive_no_completed.otx
+++ b/tests/data/StateMachine_Chk006/positive_no_completed.otx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<otx xmlns="http://iso.org/OTX/1.0.0"
+    xmlns:otx="http://iso.org/OTX/1.0.0"
+    xmlns:hmi="http://iso.org/OTX/1.0.0/HMI"
+    xmlns:event="http://iso.org/OTX/1.0.0/Event"
+    xmlns:smp="http://iso.org/OTX/1.0.0/StateMachineProcedure"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="id_d1731ec80bc14b00b12ccbae5bd159ff"
+    name="StateMachineExample" package="Examples" version="1.0.0.0"
+    timestamp="2017-11-17T00:01:03.1968545+01:00"
+    xsi:schemaLocation="http://iso.org/OTX/1.0.0 ../Core/otx.xsd
+                        http://iso.org/OTX/1.0.0/StateMachineProcedure ../ASAMExtensionInterface/otxIFD_StateMachineProcedure.xsd
+                        http://iso.org/OTX/1.0.0/HMI ../StandardInterface/otxIFD_HMI.xsd
+                        http://iso.org/OTX/1.0.0/Event ../StandardInterface/otxIFD_Event.xsd">
+    <procedures>
+        <procedure id="id_6d0c86b927da423cafae7020ed5cdcce" name="main" visibility="PUBLIC">
+            <realisation>
+                <parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </parameters>
+                <flow>
+                    <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09aea"
+                        name="ConfirmDialog1">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Start" />
+                        </realisation>
+                    </action>
+                    <action id="ProcedureCall_69433260fd1d4f74bbd9d2f5671fb73b" name="StateMachine1">
+                        <realisation xsi:type="ProcedureCall" procedure="StateMachineProcedure1">
+                            <arguments>
+                                <inArg param="Message">
+                                    <term xsi:type="StringLiteral" value="Hello World" />
+                                </inArg>
+                            </arguments>
+                        </realisation>
+                    </action>
+                    <action id="Action_baf31596e6794e41ab41ce582982f02f" name="ConfirmDialog2">
+                        <realisation xsi:type="hmi:ConfirmDialog">
+                            <hmi:message xsi:type="StringLiteral" value="Stop" />
+                        </realisation>
+                    </action>
+                </flow>
+            </realisation>
+        </procedure>
+        <procedure xsi:type="smp:StateMachineProcedure"
+            id="Procedure_8121979bd2ab413191728495b00c0c40" name="StateMachineProcedure1"
+            visibility="PUBLIC">
+            <specification>This is a new state machine procedure</specification>
+            <smp:realisation initialState="MyInitialState">
+                <smp:parameters>
+                    <inParam id="InParameterDeclaration_c2b38dec47dc42e0a9b55ccafdfdfe1c"
+                        name="Message">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </inParam>
+                </smp:parameters>
+                <smp:declarations>
+                    <variable id="Variable_baf31596e6794e41ab41ce582982f020" name="MyVariable1">
+                        <realisation>
+                            <dataType xsi:type="String" />
+                        </realisation>
+                    </variable>
+                </smp:declarations>
+                <smp:states>
+                    <smp:state id="State_baf31596e6794e41ab41ce582982f02d" name="MyInitialState">
+                        <smp:entryFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad2"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Start State" />
+                                </realisation>
+                            </action>
+                        </smp:entryFlow>
+                        <smp:triggers>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f5"
+                                name="MyTrigger1">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                            <smp:trigger id="Trigger_baf31596e6794e41ab41ce582982f0f6"
+                                name="MyTrigger2">
+                                <smp:source xsi:type="event:TimerExpiredEventSource">
+                                    <event:timeout xsi:type="IntegerLiteral" value="1000" />
+                                </smp:source>
+                            </smp:trigger>
+                        </smp:triggers>
+                        <smp:transitions>
+                            <smp:transition id="Transition_fd436028137e43488447e1a0b2896565"
+                                name="MyTransition1" target="MyCompletedState">
+                                <smp:triggerRefs>
+                                    <smp:triggerRef target="MyTrigger1" />
+                                </smp:triggerRefs>
+                                <smp:flow>
+                                    <action id="ConfirmDialog_2bd4a64b6db94bbc9bedf5e6f01503f7"
+                                        name="ConfirmDialog1">
+                                        <realisation xsi:type="hmi:ConfirmDialog">
+                                            <hmi:message xsi:type="StringValue" valueOf="Message" />
+                                        </realisation>
+                                    </action>
+                                </smp:flow>
+                            </smp:transition>
+                        </smp:transitions>
+                        <smp:exitFlow>
+                            <action id="ConfirmDialog_c8b9980a3ec542928674fb623ae09ad5"
+                                name="ConfirmDialog1">
+                                <realisation xsi:type="hmi:ConfirmDialog">
+                                    <hmi:message xsi:type="StringLiteral" value="Exit State" />
+                                </realisation>
+                            </action>
+                        </smp:exitFlow>
+                    </smp:state>
+
+                </smp:states>
+            </smp:realisation>
+        </procedure>
+    </procedures>
+</otx>

--- a/tests/test_state_machine_checks.py
+++ b/tests/test_state_machine_checks.py
@@ -102,3 +102,150 @@ def test_chk002_negative(
     assert state_machine_issues[0].level == IssueSeverity.ERROR
 
     test_utils.cleanup_files()
+
+
+def test_chk003_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk003/"
+    target_file_name = f"positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:state_machine.chk_003.no_target_state_for_completed_state"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk003_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk003/"
+    target_file_name = f"negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    state_machine_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:state_machine.chk_003.no_target_state_for_completed_state"
+    )
+    assert len(state_machine_issues) == 1
+    assert state_machine_issues[0].level == IssueSeverity.WARNING
+
+    test_utils.cleanup_files()
+
+
+def test_chk004_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk004/"
+    target_file_name = f"positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:state_machine.chk_004.mandatory_trigger"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk004_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk004/"
+    target_file_name = f"negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    state_machine_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:state_machine.chk_004.mandatory_trigger"
+    )
+    assert len(state_machine_issues) == 1
+    assert state_machine_issues[0].level == IssueSeverity.ERROR
+
+    test_utils.cleanup_files()
+
+
+def test_chk005_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk005/"
+    target_file_name = f"positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:state_machine.chk_005.mandatory_transition"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk005_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk005/"
+    target_file_name = f"negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    state_machine_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:state_machine.chk_005.mandatory_transition"
+    )
+    assert len(state_machine_issues) == 1
+    assert state_machine_issues[0].level == IssueSeverity.ERROR
+
+    test_utils.cleanup_files()

--- a/tests/test_state_machine_checks.py
+++ b/tests/test_state_machine_checks.py
@@ -249,3 +249,78 @@ def test_chk005_negative(
     assert state_machine_issues[0].level == IssueSeverity.ERROR
 
     test_utils.cleanup_files()
+
+
+def test_chk006_positive(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk006/"
+    target_file_name = f"positive.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk005_positive_no_completed(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk006/"
+    target_file_name = f"positive_no_completed.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    assert (
+        len(
+            result.get_issues_by_rule_uid(
+                "asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state"
+            )
+        )
+        == 0
+    )
+
+    test_utils.cleanup_files()
+
+
+def test_chk006_negative(
+    monkeypatch,
+) -> None:
+    base_path = "tests/data/StateMachine_Chk006/"
+    target_file_name = f"negative.otx"
+    target_file_path = os.path.join(base_path, target_file_name)
+
+    test_utils.create_test_config(target_file_path)
+
+    test_utils.launch_main(monkeypatch)
+
+    result = Result()
+    result.load_from_file(test_utils.REPORT_FILE_PATH)
+
+    state_machine_issues = result.get_issues_by_rule_uid(
+        "asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state"
+    )
+    assert len(state_machine_issues) == 1
+    assert state_machine_issues[0].level == IssueSeverity.ERROR
+
+    test_utils.cleanup_files()

--- a/tests/test_state_machine_checks.py
+++ b/tests/test_state_machine_checks.py
@@ -277,7 +277,7 @@ def test_chk006_positive(
     test_utils.cleanup_files()
 
 
-def test_chk005_positive_no_completed(
+def test_chk006_positive_no_completed(
     monkeypatch,
 ) -> None:
     base_path = "tests/data/StateMachine_Chk006/"


### PR DESCRIPTION
**Description**

Added StateMachine  checks 003, 004, 005 and 006 along with test code

Rules implemented:

003
```
    Rule ID: asam.net:otx:1.0.0:state_machine.chk_003.no_target_state_for_completed_state

    Criterion: After finishing the completed state the procedure is finished and shall return to
    the caller. Therefore the completed state shall not have a target state.
    Severity: Warning
```

004
```
 Rule ID: asam.net:otx:1.0.0:state_machine.chk_004.mandatory_trigger

    Criterion: Each state except the completed state shall have at least one trigger.
    Severity: Critical

```

005
```
 Rule ID: asam.net:otx:1.0.0:state_machine.chk_005.mandatory_transition

    Criterion: Each state except the completed state shall have at least one transition.
    Severity: Critical

```

006
```
    Rule ID: asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state

    Description: The values of the mandatory initialState and optional completedState attributes shall be distinguished.
    Severity: ERROR
```

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.

**Notes**

Sample output

003
```
 <Issue issueId="1" description="Issue flagging when a completed state has a target state" level="2" ruleUID="asam.net:otx:1.0.0:state_machine.chk_003.no_target_state_for_completed_state">
        <Locations description="Completed state MyCompletedState with id State_baf31596e6794e41ab41ce582982f023 has a target state but it should not">
          <XMLLocation xpath="{http://iso.org/OTX/1.0.0}procedures/{http://iso.org/OTX/1.0.0}procedure[2]/{http://iso.org/OTX/1.0.0/StateMachineProcedure}realisation/{http://iso.org/OTX/1.0.0/StateMachineProcedure}states/{http://iso.org/OTX/1.0.0/StateMachineProcedure}state[2]"/>
        </Locations>
      </Issue>
```

004
```
<Issue issueId="1" description="Issue flagging when a non completed state has no triggers" level="1" ruleUID="asam.net:otx:1.0.0:state_machine.chk_004.mandatory_trigger">
        <Locations description="State MyInitialState with id State_baf31596e6794e41ab41ce582982f02d does not have any trigger">
          <XMLLocation xpath="{http://iso.org/OTX/1.0.0}procedures/{http://iso.org/OTX/1.0.0}procedure[2]/{http://iso.org/OTX/1.0.0/StateMachineProcedure}realisation/{http://iso.org/OTX/1.0.0/StateMachineProcedure}states/{http://iso.org/OTX/1.0.0/StateMachineProcedure}state[1]"/>
        </Locations>
      </Issue>
```


005
```
<Issue issueId="2" description="Issue flagging when a non completed state has no transition" level="1" ruleUID="asam.net:otx:1.0.0:state_machine.chk_005.mandatory_transition">
        <Locations description="State MyInitialState with id State_baf31596e6794e41ab41ce582982f02d does not have any transition">
          <XMLLocation xpath="{http://iso.org/OTX/1.0.0}procedures/{http://iso.org/OTX/1.0.0}procedure[2]/{http://iso.org/OTX/1.0.0/StateMachineProcedure}realisation/{http://iso.org/OTX/1.0.0/StateMachineProcedure}states/{http://iso.org/OTX/1.0.0/StateMachineProcedure}state[1]"/>
        </Locations>
      </Issue>
```

006
```
 <Issue issueId="2" description="Issue flagging when initialState and completedState cannot be distinguished" level="1" ruleUID="asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state">
        <Locations description="State machine realisation cannot distinguish between initial and completed state">
          <XMLLocation xpath="{http://iso.org/OTX/1.0.0}procedures/{http://iso.org/OTX/1.0.0}procedure[2]/{http://iso.org/OTX/1.0.0/StateMachineProcedure}realisation"/>
        </Locations>
      </Issue>
```