### PR TITLE
Add checker bundle doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov
 coverage.xml
 .coverage*
 .python-version
+generated_checker_bundle_doc.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # qc-otx
 
-This project implements the [Open Test sequence eXchange (OTX)](https://report.asam.net/otx-iso-13209-open-test-sequence-exchange-format) Checker for the ASAM Quality Checker project.
+This project implements the [OTX Checker](checker_bundle_doc.md) for the ASAM Quality Checker project.
+
+OTX stands for [Open Test sequence eXchange](https://report.asam.net/otx-iso-13209-open-test-sequence-exchange-format).
 
 ## Installation
 

--- a/checker_bundle_doc.md
+++ b/checker_bundle_doc.md
@@ -1,0 +1,50 @@
+# Checker bundle: otxBundle
+
+* Build version:  0.1.0
+* Description:    OTX checker bundle
+
+## Parameters
+
+* InputFile: 
+
+## Checkers
+
+### core_otx
+
+* Description: Check if core properties of input file are properly set
+* Addressed rules:
+  * asam.net:otx:1.0.0:core.chk_001.document_name_matches_filename
+  * asam.net:otx:1.0.0:core.chk_002.document_name_package_uniqueness
+  * asam.net:otx:1.0.0:core.chk_003.no_dead_import_links
+  * asam.net:otx:1.0.0:core.chk_004.no_unused_imports
+  * asam.net:otx:1.0.0:core.chk_005.no_use_of_undefined_import_prefixes
+  * asam.net:otx:1.0.0:core.chk_006.match_of_imported_document_data_model_version
+  * asam.net:otx:1.0.0:core.chk_007.have_specification_if_no_realisation_exists
+  * asam.net:otx:1.0.0:core.chk_008.public_main_procedure
+  * asam.net:otx:1.0.0:core.chk_009.mandatory_constant_initialization
+  * asam.net:otx:1.0.0:core.chk_010.unique_node_names
+
+### data_type_otx
+
+* Description: Check if data_type properties of input file are properly set
+* Addressed rules:
+  * asam.net:otx:1.0.0:data_type.chk_001.accessing_structure_elements
+  * asam.net:otx:1.0.0:data_type.chk_008.correct_target_for_structure_element
+
+### zip_file_otx
+
+* Description: Check if zip_file properties of input file are properly set
+* Addressed rules:
+  * asam.net:otx:1.0.0:zip_file.chk_002.type_safe_zip_file
+  * asam.net:otx:1.0.0:zip_file.chk_001.type_safe_unzip_file
+
+### state_machine_otx
+
+* Description: Check if state_machine properties of input file are properly set
+* Addressed rules:
+  * asam.net:otx:1.0.0:state_machine.chk_001.no_procedure_realization
+  * asam.net:otx:1.0.0:state_machine.chk_002.mandatory_target_state
+  * asam.net:otx:1.0.0:state_machine.chk_003.no_target_state_for_completed_state
+  * asam.net:otx:1.0.0:state_machine.chk_005.mandatory_transition
+  * asam.net:otx:1.0.0:state_machine.chk_004.mandatory_trigger
+  * asam.net:otx:1.0.0:state_machine.chk_006.distinguished_initial_and_completed_state

--- a/qc_otx/main.py
+++ b/qc_otx/main.py
@@ -82,6 +82,9 @@ def main():
             )
         )
 
+        # Uncomment the follow line to generate the checker bundle documentation.
+        # result.write_markdown_doc("checker_bundle_doc.md")
+
     logging.info("Done")
 
 

--- a/qc_otx/main.py
+++ b/qc_otx/main.py
@@ -25,6 +25,8 @@ def args_entrypoint() -> argparse.Namespace:
     group.add_argument("-d", "--default_config", action="store_true")
     group.add_argument("-c", "--config_path")
 
+    parser.add_argument("-g", "--generate_markdown", action="store_true")
+
     return parser.parse_args()
 
 
@@ -82,8 +84,8 @@ def main():
             )
         )
 
-        # Uncomment the follow line to generate the checker bundle documentation.
-        # result.write_markdown_doc("checker_bundle_doc.md")
+        if args.generate_markdown:
+            result.write_markdown_doc("generated_checker_bundle_doc.md")
 
     logging.info("Done")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,11 +28,7 @@ def launch_main(monkeypatch):
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "main.py",
-            "-c",
-            CONFIG_FILE_PATH,
-        ],
+        ["main.py", "-c", CONFIG_FILE_PATH, "--generate_markdown"],
     )
     main.main()
 


### PR DESCRIPTION
**Description**

Add checker bundle doc using the automatically generated documentation supported in the baselib.

**Main changes**

1. Add an option to generate the documentation.
2. Add and link the generated documentation to README.md

**How was the PR tested?**

1. Render the generated documentation.

**Notes**

Related issue: https://github.com/asam-ev/qc-framework/issues/27