### PR TITLE
Update baselib and use Optional

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,20 +16,16 @@ name = "asam-qc-baselib"
 version = "1.0.0rc1"
 description = "Python base library for ASAM Quality Checker Framework"
 optional = false
-python-versions = "^3.10"
-files = []
-develop = false
+python-versions = "<4.0,>=3.10"
+files = [
+    {file = "asam_qc_baselib-1.0.0rc1-py3-none-any.whl", hash = "sha256:f946be44ccf31d94ba0e72d93e86888ed70925dc4d1d46287edf69c4b6c29581"},
+    {file = "asam_qc_baselib-1.0.0rc1.tar.gz", hash = "sha256:6631bd0ca6b9126fe9244d4bd0092d1a108429c773afcb43a6e6dd3c78cde76f"},
+]
 
 [package.dependencies]
-lxml = "^5.2.2"
-pydantic = "^2.7.2"
-pydantic-xml = "^2.11.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/asam-ev/qc-baselib-py.git"
-reference = "develop"
-resolved_reference = "8183d1cef7346e3c1c1972e31a98b89ea1876e10"
+lxml = ">=5.2.2,<6.0.0"
+pydantic = ">=2.7.2,<3.0.0"
+pydantic-xml = ">=2.11.0,<3.0.0"
 
 [[package]]
 name = "black"
@@ -471,13 +467,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-xml"
-version = "2.13.0"
+version = "2.13.1"
 description = "pydantic xml extension"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_xml-2.13.0-py3-none-any.whl", hash = "sha256:da6f59041c5f9ef8b33115739e3dfca55d6f8388b89fc6c234406c1c3cbe3acd"},
-    {file = "pydantic_xml-2.13.0.tar.gz", hash = "sha256:92737661c644681054bb06ed86bac492a905bfda99eaac0659ef470c8589a290"},
+    {file = "pydantic_xml-2.13.1-py3-none-any.whl", hash = "sha256:f880394e090cef43e55aa848b285ea9807011f768d682188807a741b978d7326"},
+    {file = "pydantic_xml-2.13.1.tar.gz", hash = "sha256:225d96ce8288abf84d34aa5c70cd4a834c389a7efb071f95301cbba41bfbec15"},
 ]
 
 [package.dependencies]
@@ -535,4 +531,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "da707e180971690a491b861c8354ac2c9571a2bd7836adeb12e7c8dedab93f14"
+content-hash = "e06085fb7986f48f237136aeea0cdcf511d9a8861aae8d3c44bcd8c6ec6f1b8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-asam-qc-baselib = {git = "https://github.com/asam-ev/qc-baselib-py.git", rev = "develop"}
+asam-qc-baselib = "^1.0.0rc1"
 lxml = "^5.2.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/qc_otx/checks/models.py
+++ b/qc_otx/checks/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from lxml import etree
-from typing import Union, List
+from typing import Union, List, Optional
 
 from qc_baselib import Configuration, Result
 
@@ -8,7 +8,7 @@ from qc_baselib import Configuration, Result
 @dataclass
 class QueueNode:
     element: etree._ElementTree
-    xpath: Union[str, None]
+    xpath: Optional[str]
 
 
 @dataclass
@@ -29,22 +29,22 @@ class CheckerData:
 @dataclass
 class SMTrigger:
     id: str
-    name: Union[str, None]
+    name: Optional[str]
     xml_element: etree._Element
 
 
 @dataclass
 class SMTransition:
     id: str
-    name: Union[str, None]
-    target: Union[str, None]
+    name: Optional[str]
+    target: Optional[str]
     xml_element: etree._Element
 
 
 @dataclass
 class SMState:
     id: str
-    name: Union[str, None]
+    name: Optional[str]
     is_initial: bool
     is_completed: bool
     transitions: List[SMTransition]

--- a/qc_otx/checks/utils.py
+++ b/qc_otx/checks/utils.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from typing import Union, List, Dict
+from typing import Optional, List, Dict
 from qc_otx.checks import models
 import re
 import logging
@@ -63,7 +63,7 @@ def get_all_attributes(
     return attributes
 
 
-def get_standard_schema_version(root: etree._ElementTree) -> Union[str, None]:
+def get_standard_schema_version(root: etree._ElementTree) -> Optional[str]:
     root_attrib = root.getroot().attrib
     return root_attrib["version"]
 


### PR DESCRIPTION
**Description**

This is the last PR to prepare for the release candidate v1.0.0-rc.1

**Main changes**

1. Use `asam-qc-baselib` from PyPi with version range `^1.0.0rc1`
1. Use `typing.Optional`

**How was the PR tested?**

1. Unit-test
2. Test release `asam-qc-otx` on [the test PyPi server.](https://test.pypi.org/project/asam-qc-otx/1.0.0rc1/) Install the published package locally and it works.

**Notes**
