### PR TITLE
CCB Review: Prepare v1.0.0-rc.1 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This project implements the [OTX Checker Bundle](checker_bundle_doc.md) for the 
 The ASAM Quality Checker OTX library contains a short representative list of check examples for [Open Test sequence eXchange (OTX)](https://report.asam.net/otx-iso-13209-open-test-sequence-exchange-format)
 to showcase the functionality and implementation (it shall not be a reference implementation) for the ASAM Quality Checker project. 
 
+**Disclaimer**: The current version is a release candidate. The first official release is expected to be in November.
+
 - [asam-qc-otx](#asam-qc-otx)
   - [Installation and usage](#installation-and-usage)
     - [Installation using pip](#installation-using-pip)
@@ -184,3 +186,34 @@ You need to have pre-commit installed and install the hooks:
 ```
 pre-commit install
 ```
+
+**To implement a new checker:**
+
+1. Create a new Python module for each checker.
+2. Specify the following global variables for the Python module
+
+| Variable | Meaning |
+| --- | --- |
+| `CHECKER_ID` | The ID of the checker |
+| `CHECKER_DESCRIPTION` | The description of the checker |
+| `CHECKER_PRECONDITIONS` | A set of other checkers in which if any of them raise an issue, the current checker will be skipped |
+| `RULE_UID` | The rule UID of the rule that the checker will check |
+
+3. Implement the checker logic in the following function:
+
+```python
+def check_rule(checker_data: models.CheckerData) -> None:
+    pass
+```
+
+4. Register the checker module in the following function in [main.py](qc_otx/main.py).
+
+```python
+def run_checks(config: Configuration, result: Result) -> None:
+    ...
+    # Add the following line to register your checker module
+    execute_checker(your_checker_module, checker_data)
+    ...
+```
+
+All the checkers in this checker bundle are implemented in this way. Take a look at some of them before implementing your first checker.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,21 @@ asam-qc-otx can be installed using pip or from source.
 
 asam-qc-otx can be installed using pip.
 
+**From PyPi repository**
+
+```bash
+pip install asam-qc-otx
+```
+
+**From GitHub repository**
+
 ```bash
 pip install asam-qc-otx@git+https://github.com/asam-ev/qc-otx@main
 ```
 
-**Note:** The above command will install `asam-qc-otx` from the `main` branch. If you want to install `asam-qc-otx` from another branch or tag, replace `@main` with the desired branch or tag. It is also possible to install from a local directory.
+The above command will install `asam-qc-otx` from the `main` branch. If you want to install `asam-qc-otx` from another branch or tag, replace `@main` with the desired branch or tag.
+
+**From a local repository**
 
 ```bash
 pip install /home/user/qc-otx

--- a/checker_bundle_doc.md
+++ b/checker_bundle_doc.md
@@ -1,11 +1,12 @@
 # Checker bundle: otxBundle
 
-* Build version:  0.1.0
+* Build version:  v1.0.0-rc.1
 * Description:    OTX checker bundle
 
 ## Parameters
 
 * InputFile 
+* resultFile 
 
 ## Checkers
 

--- a/manifest_templates/windows_otx_manifest.json
+++ b/manifest_templates/windows_otx_manifest.json
@@ -4,7 +4,7 @@
       "name": "otxBundle",
       "exec_type": "executable",
       "module_type": "checker_bundle",
-      "exec_command": "cd %ASAM_QC_FRAMEWORK_WORKING_DIR% && qc_otx -c %ASAM_QC_FRAMEWORK_CONFIG_FILE%"
+      "exec_command": "cd \"%ASAM_QC_FRAMEWORK_WORKING_DIR%\" && qc_otx -c \"%ASAM_QC_FRAMEWORK_CONFIG_FILE%\""
     }
   ]
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,20 +16,16 @@ name = "asam-qc-baselib"
 version = "1.0.0rc1"
 description = "Python base library for ASAM Quality Checker Framework"
 optional = false
-python-versions = "^3.10"
-files = []
-develop = false
+python-versions = "<4.0,>=3.10"
+files = [
+    {file = "asam_qc_baselib-1.0.0rc1-py3-none-any.whl", hash = "sha256:f946be44ccf31d94ba0e72d93e86888ed70925dc4d1d46287edf69c4b6c29581"},
+    {file = "asam_qc_baselib-1.0.0rc1.tar.gz", hash = "sha256:6631bd0ca6b9126fe9244d4bd0092d1a108429c773afcb43a6e6dd3c78cde76f"},
+]
 
 [package.dependencies]
-lxml = "^5.2.2"
-pydantic = "^2.7.2"
-pydantic-xml = "^2.11.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/asam-ev/qc-baselib-py.git"
-reference = "develop"
-resolved_reference = "8183d1cef7346e3c1c1972e31a98b89ea1876e10"
+lxml = ">=5.2.2,<6.0.0"
+pydantic = ">=2.7.2,<3.0.0"
+pydantic-xml = ">=2.11.0,<3.0.0"
 
 [[package]]
 name = "black"
@@ -471,13 +467,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-xml"
-version = "2.13.0"
+version = "2.13.1"
 description = "pydantic xml extension"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_xml-2.13.0-py3-none-any.whl", hash = "sha256:da6f59041c5f9ef8b33115739e3dfca55d6f8388b89fc6c234406c1c3cbe3acd"},
-    {file = "pydantic_xml-2.13.0.tar.gz", hash = "sha256:92737661c644681054bb06ed86bac492a905bfda99eaac0659ef470c8589a290"},
+    {file = "pydantic_xml-2.13.1-py3-none-any.whl", hash = "sha256:f880394e090cef43e55aa848b285ea9807011f768d682188807a741b978d7326"},
+    {file = "pydantic_xml-2.13.1.tar.gz", hash = "sha256:225d96ce8288abf84d34aa5c70cd4a834c389a7efb071f95301cbba41bfbec15"},
 ]
 
 [package.dependencies]
@@ -535,4 +531,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "da707e180971690a491b861c8354ac2c9571a2bd7836adeb12e7c8dedab93f14"
+content-hash = "e06085fb7986f48f237136aeea0cdcf511d9a8861aae8d3c44bcd8c6ec6f1b8e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,7 +13,7 @@ files = [
 
 [[package]]
 name = "asam-qc-baselib"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Python base library for ASAM Quality Checker Framework"
 optional = false
 python-versions = "^3.10"
@@ -29,7 +29,7 @@ pydantic-xml = "^2.11.0"
 type = "git"
 url = "https://github.com/asam-ev/qc-baselib-py.git"
 reference = "develop"
-resolved_reference = "bfed12fc6f1bbd2cab97f74a6c9aa0e0faaef7b3"
+resolved_reference = "8183d1cef7346e3c1c1972e31a98b89ea1876e10"
 
 [[package]]
 name = "black"
@@ -471,13 +471,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-xml"
-version = "2.12.1"
+version = "2.13.0"
 description = "pydantic xml extension"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_xml-2.12.1-py3-none-any.whl", hash = "sha256:5de8394dde00d00a899b85fd8e0b915e6f144a068675d8efcbaa225fdcce3880"},
-    {file = "pydantic_xml-2.12.1.tar.gz", hash = "sha256:31623e9b287ef9eb1dda4caa92e893e3ac977f0327e1d76fd8a36879e455cea1"},
+    {file = "pydantic_xml-2.13.0-py3-none-any.whl", hash = "sha256:da6f59041c5f9ef8b33115739e3dfca55d6f8388b89fc6c234406c1c3cbe3acd"},
+    {file = "pydantic_xml-2.13.0.tar.gz", hash = "sha256:92737661c644681054bb06ed86bac492a905bfda99eaac0659ef470c8589a290"},
 ]
 
 [package.dependencies]
@@ -512,13 +512,13 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.0.2"
 description = "A lil' TOML parser"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
+    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-asam-qc-baselib = {git = "https://github.com/asam-ev/qc-baselib-py.git", rev = "develop"}
+asam-qc-baselib = "^1.0.0rc1"
 lxml = "^5.2.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asam-qc-otx"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "This project implements the Open Test sequence eXchange Checker for the ASAM Quality Checker project."
 authors = ["Danilo Romano <danilo@ivex.ai>"]
 license = "MPL-2.0"

--- a/qc_otx/checks/models.py
+++ b/qc_otx/checks/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from lxml import etree
-from typing import Union, List
+from typing import Union, List, Optional
 
 from qc_baselib import Configuration, Result
 
@@ -8,7 +8,7 @@ from qc_baselib import Configuration, Result
 @dataclass
 class QueueNode:
     element: etree._ElementTree
-    xpath: Union[str, None]
+    xpath: Optional[str]
 
 
 @dataclass
@@ -29,22 +29,22 @@ class CheckerData:
 @dataclass
 class SMTrigger:
     id: str
-    name: Union[str, None]
+    name: Optional[str]
     xml_element: etree._Element
 
 
 @dataclass
 class SMTransition:
     id: str
-    name: Union[str, None]
-    target: Union[str, None]
+    name: Optional[str]
+    target: Optional[str]
     xml_element: etree._Element
 
 
 @dataclass
 class SMState:
     id: str
-    name: Union[str, None]
+    name: Optional[str]
     is_initial: bool
     is_completed: bool
     transitions: List[SMTransition]

--- a/qc_otx/checks/utils.py
+++ b/qc_otx/checks/utils.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from typing import Union, List, Dict
+from typing import Optional, List, Dict
 from qc_otx.checks import models
 import re
 import logging
@@ -63,7 +63,7 @@ def get_all_attributes(
     return attributes
 
 
-def get_standard_schema_version(root: etree._ElementTree) -> Union[str, None]:
+def get_standard_schema_version(root: etree._ElementTree) -> Optional[str]:
     root_attrib = root.getroot().attrib
     return root_attrib["version"]
 

--- a/qc_otx/constants.py
+++ b/qc_otx/constants.py
@@ -1,2 +1,2 @@
 BUNDLE_NAME = "otxBundle"
-BUNDLE_VERSION = "0.1.0"
+BUNDLE_VERSION = "v1.0.0-rc.1"

--- a/qc_otx/main.py
+++ b/qc_otx/main.py
@@ -203,7 +203,6 @@ def main():
     result = Result()
     result.register_checker_bundle(
         name=constants.BUNDLE_NAME,
-        build_date=datetime.today().strftime("%Y-%m-%d"),
         description="OTX checker bundle",
         version=constants.BUNDLE_VERSION,
         summary="",


### PR DESCRIPTION
**Description**

This PR prepares for the release candidate 1.0.0rc1. After this PR is merged into `main`, the tag `v1.0.0-rc1` will be created and the Python package `asam-qc-otx 1.0.0rc1` will be published to PyPi.

**Main changes**

1. Add release disclaimer
2. Remove the optional argument `build_date` when registering checker bundle
3. Add documentation about how to implement new checkers
4. Add quotation to example windows manifest to handle spaces (https://github.com/asam-ev/qc-framework/issues/189)
5. Use `asam-qc-baselib` from the official PyPi server with the version range `^1.0.0rc1`
6. Use `typing.Optional` instead of `Union[None, ...]`.

**How was the PR tested?**

1. Tests are documented in each PR below.

**Notes**

A test release in the Test PyPi server is available [here](https://test.pypi.org/project/asam-qc-otx/1.0.0rc1/).